### PR TITLE
Rebuy Feature

### DIFF
--- a/addLog.js
+++ b/addLog.js
@@ -14,7 +14,7 @@ process.env.CPBB_CURRENCY = process.argv[3];
 process.env.CPBB_VOL = process.argv[4];
 process.env.CPBB_APY = process.argv[5];
 
-const { add } = require("mathjs");
+const { add, format } = require("mathjs");
 const action = require('./lib/action');
 const config = require("./config");
 const log = require('./lib/log');
@@ -31,7 +31,7 @@ if (process.argv.length !== 9) {
   return log.error('invalid arguments, invoke like so: node addLog.js BTC USD 50 20 2020-11-26T16:35:00.706Z 16915.52 0.00295586');
 }
 
-log.ok(`history loaded: holding ${add(memory.lastLog.Holding, memory.lastLog.Shares)} ${config.ticker} worth ${memory.lastLog.EndValue}, liquid profit ${memory.lastLog.Profit}`);
+log.ok(`history loaded: holding ${format(add(memory.lastLog.Holding, memory.lastLog.Shares), {notation: "fixed",precision:8})} ${config.ticker} worth ${memory.lastLog.EndValue}, liquid profit ${memory.lastLog.Profit}`);
 
 
 (async () => {

--- a/coinbase/delete.order.js
+++ b/coinbase/delete.order.js
@@ -1,0 +1,13 @@
+// https://docs.pro.coinbase.com/#cancel-an-order
+
+const request = require("./cb.request");
+
+module.exports = async (id) => {
+  if (process.env.CPBB_DRY_RUN) {
+    return true;
+  }
+  return request({
+    requestPath: `/orders/${id}`,
+    method: "DELETE"
+  });
+};

--- a/coinbase/order.js
+++ b/coinbase/order.js
@@ -10,6 +10,7 @@ module.exports = async (opts) => {
     // fake out a .002 fee subtraction
     const converted = multiply(Number(opts.funds), 0.998);
     return {
+      executed_value: Number(opts.funds),
       filled_size: numFix(divide(converted, memory.price), 8),
       settled: true,
     };

--- a/config.js
+++ b/config.js
@@ -44,4 +44,11 @@ if (!fs.existsSync(config.history_file)) {
   console.log("creating log file from template", config.history_file);
   fs.copyFileSync(`${__dirname}/data/history.tsv`, config.history_file);
 }
+config.maker_file = `${__dirname}/data/maker.orders.${historyName}${historySubName}.json`;
+log.ok(config.maker_file);
+if (!fs.existsSync(config.maker_file)) {
+  // copy the template
+  console.log("creating maker file from template", config.maker_file);
+  fs.copyFileSync(`${__dirname}/data/maker.orders.json`, config.maker_file);
+}
 module.exports = config;

--- a/data/maker.orders.json
+++ b/data/maker.orders.json
@@ -1,0 +1,4 @@
+{
+  "description": "This file stores any active maker orders that may be sitting on the books and awaiting price drop to fill",
+  "orders": []
+}

--- a/data/memory.js
+++ b/data/memory.js
@@ -1,8 +1,11 @@
 // shared application memory module
 const history = require('../lib/history')
+// load up any maker orders from a previous process launch
+const makerOrders = require('./maker.orders.json')
 
 module.exports = {
   account: {},
   firstLog: history.first(),
-  lastLog: history.last()
+  lastLog: history.last(),
+  makerOrders
 }

--- a/data/memory.js
+++ b/data/memory.js
@@ -1,11 +1,11 @@
 // shared application memory module
-const history = require('../lib/history')
-// load up any maker orders from a previous process launch
-const makerOrders = require('./maker.orders.json')
+const history = require('../lib/history');
+
+const config = require('../config');
 
 module.exports = {
   account: {},
   firstLog: history.first(),
   lastLog: history.last(),
-  makerOrders
-}
+  makerOrders: require(config.maker_file)
+};

--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ const job = new CronJob(config.freq, action);
   if(process.env.CPBB_REBUY_AT){
     log.now(`${config.productID}: REBUY up to ${process.env.CPBB_REBUY_MAX} limit orders or $${process.env.CPBB_REBUY_VOL}, for ${process.env.CPBB_REBUY_SIZE}${process.env.CPBB_REBUY_MULTIPLIER?`(x${process.env.CPBB_REBUY_MULTIPLIER})`:''} @ ${process.env.CPBB_REBUY_AT}% drops`);
   }
-  if(process.env.CPBB_REBUY_ONLY){
+  if(process.env.CPBB_REBUY_ONLY==='true'){
     // this mode says "I want to buy this asset, but only when it's flashing downward during the timing interval"
     log.now(`${config.productID} set to REBUY ONLY MODE (will not create market taker trades, only limit orders at drops)`);
   }

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ const { CronJob } = require("cron");
 
 const config = require("./config");
 
-const { add } = require("mathjs");
+const { add, format } = require("mathjs");
 const action = require("./lib/action");
 const getAccounts = require("./coinbase/accounts");
 const loadLastLog = require('./lib/load.lastLog');
@@ -14,19 +14,22 @@ const job = new CronJob(config.freq, action);
 
 (async () => {
   log.now(
-    `🤖 Position Builder Bot ${config.pjson.version}, ${
-    config.api
-    } in ${process.env.CPBB_DRY_RUN ? "DRY RUN" : "LIVE"} mode, ${
-    config.vol
-    } $${config.currency} ➡️  $${config.ticker} @ cron(${
-    config.freq
-    }), ${config.apy * 100}% APY target, ${process.env.VERBOSE ? `verbose` : 'ledger'} logging`
+    `🤖 Position Builder Bot ${config.pjson.version}, ${config.api
+    } in ${process.env.CPBB_DRY_RUN ? "DRY RUN" : "LIVE"} mode, ${config.vol
+    } $${config.currency} ➡️  $${config.ticker} @ cron(${config.freq
+    }), ${config.apy * 100}% APY, ${process.env.VERBOSE ? `verbose` : 'ledger'} logging`
   );
+  if(process.env.CPBB_REBUY_AT){
+    log.now(`${config.productID}: REBUY up to ${process.env.CPBB_REBUY_MAX} limit orders or $${process.env.CPBB_REBUY_VOL}, for ${process.env.CPBB_REBUY_SIZE}${process.env.CPBB_REBUY_MULTIPLIER?`(x${process.env.CPBB_REBUY_MULTIPLIER})`:''} @ ${process.env.CPBB_REBUY_AT}% drops`);
+  }
+  if(process.env.CPBB_REBUY_ONLY){
+    // this mode says "I want to buy this asset, but only when it's flashing downward during the timing interval"
+    log.now(`${config.productID} set to REBUY ONLY MODE (will not create market taker trades, only limit orders at drops)`);
+  }
 
   // console.log(memory.lastLog);
 
-
-  log.ok(`history loaded: holding ${add(memory.lastLog.Holding, memory.lastLog.Shares)} ${config.ticker} worth ${memory.lastLog.EndValue}, liquid profit ${memory.lastLog.Profit}`)
+  log.ok(`history loaded: holding ${format(add(memory.lastLog.Holding, memory.lastLog.Shares), {notation: "fixed",precision:8})} ${config.ticker} worth ${memory.lastLog.EndValue}, liquid profit ${memory.lastLog.Profit}`)
 
   const accounts = await getAccounts().catch((e) => console.error(e));
 

--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ const job = new CronJob(config.freq, action);
     }), ${config.apy * 100}% APY, ${process.env.VERBOSE ? `verbose` : 'ledger'} logging`
   );
   if(process.env.CPBB_REBUY_AT){
-    log.now(`${config.productID}: REBUY up to ${process.env.CPBB_REBUY_MAX} limit orders or $${process.env.CPBB_REBUY_VOL}, for ${process.env.CPBB_REBUY_SIZE}${process.env.CPBB_REBUY_MULTIPLIER?`(x${process.env.CPBB_REBUY_MULTIPLIER})`:''} @ ${process.env.CPBB_REBUY_AT}% drops`);
+    log.now(`${config.productID}: REBUY up to $${process.env.CPBB_REBUY_MAX}, for ${process.env.CPBB_REBUY_SIZE} @ ${process.env.CPBB_REBUY_AT}% drops`);
   }
   if(process.env.CPBB_REBUY_ONLY==='true'){
     // this mode says "I want to buy this asset, but only when it's flashing downward during the timing interval"

--- a/index.js
+++ b/index.js
@@ -20,7 +20,9 @@ const job = new CronJob(config.freq, action);
     }), ${config.apy * 100}% APY, ${process.env.VERBOSE ? `verbose` : 'ledger'} logging`
   );
   if(process.env.CPBB_REBUY_AT){
-    log.now(`${config.productID}: REBUY up to $${process.env.CPBB_REBUY_MAX}, for ${process.env.CPBB_REBUY_SIZE} @ ${process.env.CPBB_REBUY_AT}% drops`);
+    const sizes = process.env.CPBB_REBUY_SIZE.split(',');
+    const drops = process.env.CPBB_REBUY_AT.split(',');
+    log.now(`${config.productID}: REBUY up to $${process.env.CPBB_REBUY_MAX} of ${sizes.map((s,i)=>`${s}@${drops[i]}%`).join(', ')}`);
   }
   if(process.env.CPBB_REBUY_ONLY==='true'){
     // this mode says "I want to buy this asset, but only when it's flashing downward during the timing interval"

--- a/lib/action.js
+++ b/lib/action.js
@@ -7,8 +7,17 @@ const log = require("./log");
 const memory = require("../data/memory");
 const processOrder = require("./process.order");
 const saveLog = require("./log.save");
+const postRebuys = require("./rebuys.post");
+const checkRebuys = require("./rebuys.check");
 
 module.exports = async (opts) => {
+
+  // before processing this period, we need to check on any pending market rebuy orders
+  if (memory.makerOrders.orders.length) {
+    await checkRebuys();
+  }
+
+  // ok, now we can move on with the primary action
   const ticker = opts && opts.tickerOverride ? opts.tickerOverride : await getTicker();
 
   // store the latest price
@@ -19,6 +28,12 @@ module.exports = async (opts) => {
   memory.price = config.reverse ? divide(1, Number(ticker.price)) : Number(ticker.price);
   ticker.price = memory.price;
   log.debug("ticker", ticker);
+
+  if(process.env.CPBB_REBUY_ONLY){
+    await postRebuys(ticker.price);
+    return;
+  }
+
   const action = await calculateAction(ticker);
   log.debug("action", action);
   let order = await processOrder(action);
@@ -39,6 +54,13 @@ module.exports = async (opts) => {
   // and we need to fetch it again to get completion data
   let response = order;
   if (!response.settled) response = await getOrder(order);
+
+  // if configured to add limit rebuy orders with the sold profits, do so now
+  if (process.env.CPBB_REBUY_VOL && action.funds < 0) { // just sold
+    // get the real executed price (not the value from the ticker request)
+    const basePrice = divide(Number(response.executed_value), Number(response.filled_size));
+    await postRebuys(basePrice);
+  }
 
   log.debug({ response });
 

--- a/lib/action.js
+++ b/lib/action.js
@@ -29,7 +29,7 @@ module.exports = async (opts) => {
   ticker.price = memory.price;
   log.debug("ticker", ticker);
 
-  if(process.env.CPBB_REBUY_ONLY){
+  if(process.env.CPBB_REBUY_ONLY==='true'){
     await postRebuys(ticker.price);
     return;
   }

--- a/lib/action.js
+++ b/lib/action.js
@@ -56,7 +56,7 @@ module.exports = async (opts) => {
   if (!response.settled) response = await getOrder(order);
 
   // if configured to add limit rebuy orders with the sold profits, do so now
-  if (process.env.CPBB_REBUY_VOL && action.funds < 0) { // just sold
+  if (process.env.CPBB_REBUY_MAX && action.funds < 0) { // just sold
     // get the real executed price (not the value from the ticker request)
     const basePrice = divide(Number(response.executed_value), Number(response.filled_size));
     await postRebuys(basePrice);

--- a/lib/calculate.action.js
+++ b/lib/calculate.action.js
@@ -4,14 +4,17 @@ const MS_PER_YEAR = 31556952000;
 const config = require("../config");
 const { add, divide, multiply, pow, subtract } = require("mathjs");
 const memory = require("../data/memory");
-module.exports = async (ticker) => {
-  const action = {};
-  action.dateNow = ticker.dateOverride || new Date();
+module.exports = async ({ dateOverride, forceBuy, price, type, volOverride }) => {
+  const vol = volOverride || config.vol; // we override volume with the rebuy option
+  const action = {
+    type: type || 'market'
+  };
+  action.dateNow = dateOverride || new Date();
   action.dateLast = memory.lastLog.Time
     ? new Date(memory.lastLog.Time)
     : action.dateNow;
   action.msPassed = action.dateNow - action.dateLast; // milliseconds delta
-  action.exchangeRate = ticker.price;
+  action.exchangeRate = price;
   action.currentHolding = add(memory.lastLog.Holding, memory.lastLog.Shares);
   // we get the period rate for the APY by taking the APY (e.g. 10% as 1.10) and raising it to the power
   // of the delta in time, then subtract 1 to get the change multiplier
@@ -22,7 +25,7 @@ module.exports = async (ticker) => {
   action.value = multiply(action.currentHolding, action.exchangeRate);
   // make sure our target can handle selling the vol
   // we want our position to grow by the expected gain + our vol target + the last target (accumulates APY expectation)
-  action.target = add(config.vol, action.expectedGain, memory.lastLog.Target);
+  action.target = add(vol, action.expectedGain, memory.lastLog.Target);
   if (memory.lastLog.Funds < 0) {
     // however, if we sold on the last action, that vol shouldn't add to our growth target
     action.target = add(action.target, memory.lastLog.Funds);
@@ -30,8 +33,9 @@ module.exports = async (ticker) => {
   action.diff = subtract(action.value, action.target);
   // simply, if our account value is above the target, sell, else buy
   // the `funds` is our market buy/sell amount in the base currency
-  const tradeValue = process.env.CPBB_LIQUIDATE ? action.value : config.vol;
-  action.funds = action.diff > 0 ? tradeValue * -1 : config.vol;
+  const tradeValue = process.env.CPBB_LIQUIDATE ? action.value : vol;
+  // in the case of a limit order that was filled, we are forcing the calculation to have already bought (can't calc a sell)
+  action.funds = forceBuy ? tradeValue : (action.diff > 0 ? tradeValue * -1 : tradeValue);
   action.endValue = add(action.value, action.funds);
   action.realized = add(
     memory.lastLog.Realized,

--- a/lib/process.order.js
+++ b/lib/process.order.js
@@ -1,9 +1,21 @@
 const config = require("../config");
 const order = require("../coinbase/order");
-module.exports = async (action) =>
-  order({
-    type: "market",
-    side: action.funds > 0 ? "buy" : "sell",
-    funds: Math.abs(action.funds) + "",
+module.exports = async (action) => {
+  const type = action.type || "market";
+  const side = action.funds > 0 ? "buy" : "sell";
+  const opts = type === 'limit' ? {
+    size: action.size,
+    post_only: true,
+    price: action.price,
     product_id: config.productID,
-  });
+    side,
+    type,
+  } : { // market
+      funds: Math.abs(action.funds) + "",
+      product_id: config.productID,
+      side,
+      type
+    };
+  return order(opts);
+}
+

--- a/lib/rebuys.check.js
+++ b/lib/rebuys.check.js
@@ -1,4 +1,5 @@
 const { divide } = require('mathjs');
+const config = require('../config');
 const calculateAction = require('./calculate.action');
 const deleteOrder = require("../coinbase/delete.order");
 const getOrder = require("../coinbase/get.order");
@@ -9,8 +10,10 @@ const saveLog = require("./log.save");
 module.exports = async () => {
   // check to see if any filled and add them to the ledger if they have
   // cancel any others (so we have a clean slate)
-  for (let i = 0; i < memory.makerOrders.orders.length; i++) {
-    let order = memory.makerOrders.orders[i];
+  // only pending orders for this pair (in case we are running multiple processes for different products)
+  const pendingOrders = memory.makerOrders.orders.filter(o=>o.pair ===config.productID);
+  for (let i = 0; i < pendingOrders.length; i++) {
+    let order = pendingOrders[i];
     log.debug(`checking order`, order);
     let response = await getOrder(order);
     // 404 (order was manually deleted or purged via market maintenance)
@@ -40,5 +43,5 @@ module.exports = async () => {
       deleteOrder(order.id); // no need to await
     }
   }
-  memory.makerOrders.orders = []; // purge these from the active memory of orders to track (they either filled or were deleted)
+  memory.makerOrders.orders = memory.makerOrders.orders.filter(o=>o.pair!==config.productID); // purge these from the active memory of orders to track (they either filled or were deleted)
 }

--- a/lib/rebuys.check.js
+++ b/lib/rebuys.check.js
@@ -2,6 +2,7 @@ const { divide } = require('mathjs');
 const config = require('../config');
 const calculateAction = require('./calculate.action');
 const deleteOrder = require("../coinbase/delete.order");
+const fs = require('fs');
 const getOrder = require("../coinbase/get.order");
 const log = require("./log");
 const memory = require("../data/memory");

--- a/lib/rebuys.check.js
+++ b/lib/rebuys.check.js
@@ -45,4 +45,6 @@ module.exports = async () => {
     }
   }
   memory.makerOrders.orders = memory.makerOrders.orders.filter(o=>o.pair!==config.productID); // purge these from the active memory of orders to track (they either filled or were deleted)
+  // save makerOrders to disk in case this process crashes
+  fs.writeFileSync(config.maker_file, JSON.stringify(memory.makerOrders, null, 2));
 }

--- a/lib/rebuys.check.js
+++ b/lib/rebuys.check.js
@@ -39,7 +39,7 @@ module.exports = async () => {
       });
     } else {
       // delete the order from the books (it had its chance)
-      log.now(`🚫 canceled limit order ${order.id} for ${order.size} ${config.ticker} @ ${oreder.price} = $${order.funds}`);
+      log.now(`🚫 canceled limit order ${order.id} for ${order.size} ${config.ticker} @ ${order.price} = $${order.funds}`);
 
       deleteOrder(order.id); // no need to await
     }

--- a/lib/rebuys.check.js
+++ b/lib/rebuys.check.js
@@ -39,7 +39,8 @@ module.exports = async () => {
       });
     } else {
       // delete the order from the books (it had its chance)
-      log.debug(`limit order cleanup ${order.id} of`, order)
+      log.now(`🚫 canceled limit order ${order.id} for ${order.size} ${config.ticker} @ ${oreder.price} = $${order.funds}`);
+
       deleteOrder(order.id); // no need to await
     }
   }

--- a/lib/rebuys.check.js
+++ b/lib/rebuys.check.js
@@ -1,0 +1,44 @@
+const { divide } = require('mathjs');
+const calculateAction = require('./calculate.action');
+const deleteOrder = require("../coinbase/delete.order");
+const getOrder = require("../coinbase/get.order");
+const log = require("./log");
+const memory = require("../data/memory");
+const numberFix = require('./number.fix');
+const saveLog = require("./log.save");
+module.exports = async () => {
+  // check to see if any filled and add them to the ledger if they have
+  // cancel any others (so we have a clean slate)
+  for (let i = 0; i < memory.makerOrders.orders.length; i++) {
+    let order = memory.makerOrders.orders[i];
+    log.debug(`checking order`, order);
+    let response = await getOrder(order);
+    // 404 (order was manually deleted or purged via market maintenance)
+    if(!response) continue; // ignore this order
+    if (response.settled) { // filled!
+      // add it to the history
+      // and set the funding value to the amount that was truly transacted
+      let funds = Number(response.executed_value);
+      let price = numberFix(divide(funds, Number(response.filled_size)), 2);
+      let action = await calculateAction({
+        dateOverride: new Date(response.done_at),
+        forceBuy: true,
+        price,
+        type: 'limit',
+        volOverride: numberFix(funds, 2)
+      });
+      // force the action to be a buy (even though it may have calculated that it should have sold)
+      action.funds = Math.abs(action.funds);
+      log.debug(`limit order filled!`, {order, response, action});
+      saveLog({
+        action,
+        response,
+      });
+    } else {
+      // delete the order from the books (it had its chance)
+      log.debug(`limit order cleanup ${order.id} of`, order)
+      deleteOrder(order.id); // no need to await
+    }
+  }
+  memory.makerOrders.orders = []; // purge these from the active memory of orders to track (they either filled or were deleted)
+}

--- a/lib/rebuys.post.js
+++ b/lib/rebuys.post.js
@@ -3,7 +3,7 @@
  * Sample env config:
 // should the engine only create and manage the limit orders and not make normal accumulation trades
 // useful for testing this feature
-CPBB_REBUY_ONLY: true,
+CPBB_REBUY_ONLY: false,
 // place up to 2 maker limit orders on the books after a sell action
 CPBB_REBUY_MAX: 2,
 // maximum dollar value consumed by limit order placements

--- a/lib/rebuys.post.js
+++ b/lib/rebuys.post.js
@@ -29,7 +29,7 @@ module.exports = async (basePrice) => {
   // only set orders until they reach this threshold total
   const maxFunds = Number(process.env.CPBB_REBUY_VOL);
   let size = Number(process.env.CPBB_REBUY_SIZE);
-  const multiplier = process.env.CPBB_REBUY_MULTIPLIER;
+  const multiplier = Number(process.env.CPBB_REBUY_MULTIPLIER);
   let usedFunds = 0; // counter
   log.debug(
     `REBUY: setting up to ${process.env.CPBB_REBUY_MAX} limit orders, up to $${maxFunds}, for ${size}${multiplier?` (x${multiplier})`:''} ${config.ticker} @ ${process.env.CPBB_REBUY_AT}% drops`

--- a/lib/rebuys.post.js
+++ b/lib/rebuys.post.js
@@ -12,7 +12,7 @@ CPBB_REBUY_SIZE: ".0001,.0001,.0002,.0002,.0003,.0003,.0004,.0004,.0005,.0005",
 // note: you have to define at least the number of points in CPBB_REBUY_SIZE
 CPBB_REBUY_AT: "-1,-2,-4,-8,-16,-20,-30,-40,-50,-80",
  */
-const { add, divide, multiply } = require('mathjs');
+const { add, divide, format, multiply } = require('mathjs');
 const config = require('../config');
 const fs = require('fs');
 const log = require("./log");

--- a/lib/rebuys.post.js
+++ b/lib/rebuys.post.js
@@ -46,6 +46,7 @@ module.exports = async (basePrice) => {
     };
     let orderResponse = await processOrder(order);
     log.debug({ order, orderResponse });
+    log.now(`⬇️ posted limit order for ${size} ${config.ticker} @ ${price} = $${funds} (${percentageDrop*100}% drop)`);
     memory.makerOrders.orders.push({
       pair: config.productID,
       funds,

--- a/lib/rebuys.post.js
+++ b/lib/rebuys.post.js
@@ -24,13 +24,12 @@ module.exports = async (basePrice) => {
   // only set orders until they reach this threshold total
   const maxFunds = Number(process.env.CPBB_REBUY_MAX);
   const sizes = process.env.CPBB_REBUY_SIZE.split(',').map(s=>Number(s));
-  let usedFunds = 0; // counter
-  // place up to CPBB_REBUY_MAX limit orders
+  let usedFunds = 0;
   for (let i = 0; i < sizes.length; i++) {
-    let percentageDrop = dropPoints[i]; // e.g. -.5%, -1%, etc
+    let percentageDrop = dropPoints[i];
     let size = sizes[i];
     let price = add(basePrice, multiply(basePrice, percentageDrop)).toFixed(2);
-    let funds = multiply(size, price);
+    let funds = format(multiply(size, price), { notation: 'fixed', precision: 4 });
     if(add(usedFunds, funds) > maxFunds){
       break; // stop processing
     }
@@ -43,7 +42,7 @@ module.exports = async (basePrice) => {
     };
     let orderResponse = await processOrder(order);
     log.debug({ order, orderResponse });
-    log.now(`⬇️ posted limit order for ${size} ${config.ticker} @ ${price} = $${funds} (${percentageDrop*100}% drop)`);
+    log.now(`⬇️  posted limit order for ${size} ${config.ticker} @ ${price} = $${funds} (${percentageDrop*100}% drop)`);
     memory.makerOrders.orders.push({
       pair: config.productID,
       funds,

--- a/lib/rebuys.post.js
+++ b/lib/rebuys.post.js
@@ -54,6 +54,7 @@ module.exports = async (basePrice) => {
     let orderResponse = await processOrder(order);
     log.debug({ order, orderResponse });
     memory.makerOrders.orders.push({
+      pair: config.productID,
       funds,
       id: orderResponse.id,
       price,

--- a/lib/rebuys.post.js
+++ b/lib/rebuys.post.js
@@ -11,11 +11,11 @@ CPBB_REBUY_VOL: 50,
 // minimum order is in BTC (.0001, which is $5 at $50K, or $2 at $20K)
 // rebuy logic will place up to CPBB_REBUY_MAX orders at this size until CPBB_REBUY_VOL is reached
 CPBB_REBUY_SIZE: .0001,
-// should the size be doubled at each percentage drop (.e.g .0001, .0002)?
+// should the size be doubled (or otherwise multiplied) at each percentage drop (.e.g .0001, .0002)?
 // acts as a multiplier if you want to just go to .00015 with 1.5
 CPBB_REBUY_MULTIPLIER: 2,
-// -0.5% intervals (e.g. -0.05%, -0.01%, -0.15%, -0.2%, -0.25%, -0.3%, -0.35%, -0.4%)
-CPBB_REBUY_AT: -0.05,
+// rebuy at these percentage drop targets (-1%, -2%, etc)
+CPBB_REBUY_AT: "-1,-2,-4,-8,-16",
  */
 const { add, divide, multiply } = require('mathjs');
 const config = require('../config');
@@ -25,7 +25,7 @@ const memory = require("../data/memory");
 const processOrder = require('./process.order');
 module.exports = async (basePrice) => {
   // starting percentage down from basePrice to place limit orders
-  const baseDrop = divide(Number(process.env.CPBB_REBUY_AT), 100);
+  const dropPoints = process.env.CPBB_REBUY_AT.split(',').map(p=>divide(Number(p), 100));
   // only set orders until they reach this threshold total
   const maxFunds = Number(process.env.CPBB_REBUY_VOL);
   let size = Number(process.env.CPBB_REBUY_SIZE);
@@ -36,7 +36,7 @@ module.exports = async (basePrice) => {
   );
   // place up to CPBB_REBUY_MAX limit orders
   for (let i = 0; i < process.env.CPBB_REBUY_MAX; i++) {
-    let percentageDrop = multiply(baseDrop, i + 1); // e.g. -.5%, -1%, etc
+    let percentageDrop = dropPoints[i]; // e.g. -.5%, -1%, etc
     let price = add(basePrice, multiply(basePrice, percentageDrop)).toFixed(2);
     // if we are multiplying the btc size each drop point, do so (only if not the first order)
     if(multiplier && i) size = multiply(size, multiplier);

--- a/lib/rebuys.post.js
+++ b/lib/rebuys.post.js
@@ -52,7 +52,7 @@ module.exports = async (basePrice) => {
       size
     });
   }
-  log.debug(`REBUY: set ${memory.makerOrders.orders.length} limit orders totalling $${usedFunds}`)
+  log.debug(`REBUY: set ${memory.makerOrders.orders.length} limit orders totalling $${usedFunds}`);
   // save makerOrders to disk in case this process crashes
-  fs.writeFileSync(`${__dirname}/../data/maker.orders.json`, JSON.stringify(memory.makerOrders, null, 2));
+  fs.writeFileSync(config.maker_file, JSON.stringify(memory.makerOrders, null, 2));
 }

--- a/lib/rebuys.post.js
+++ b/lib/rebuys.post.js
@@ -4,18 +4,13 @@
 // should the engine only create and manage the limit orders and not make normal accumulation trades
 // useful for testing this feature
 CPBB_REBUY_ONLY: false,
-// place up to 2 maker limit orders on the books after a sell action
-CPBB_REBUY_MAX: 2,
 // maximum dollar value consumed by limit order placements
-CPBB_REBUY_VOL: 50,
-// minimum order is in BTC (.0001, which is $5 at $50K, or $2 at $20K)
-// rebuy logic will place up to CPBB_REBUY_MAX orders at this size until CPBB_REBUY_VOL is reached
-CPBB_REBUY_SIZE: .0001,
-// should the size be doubled (or otherwise multiplied) at each percentage drop (.e.g .0001, .0002)?
-// acts as a multiplier if you want to just go to .00015 with 1.5
-CPBB_REBUY_MULTIPLIER: 2,
+CPBB_REBUY_MAX: 50,
+// rebuy logic will place up to  orders at this size until CPBB_REBUY_MAX is reached
+CPBB_REBUY_SIZE: ".0001,.0001,.0002,.0002,.0003,.0003,.0004,.0004,.0005,.0005",
 // rebuy at these percentage drop targets (-1%, -2%, etc)
-CPBB_REBUY_AT: "-1,-2,-4,-8,-16",
+// note: you have to define at least the number of points in CPBB_REBUY_SIZE
+CPBB_REBUY_AT: "-1,-2,-4,-8,-16,-20,-30,-40,-50,-80",
  */
 const { add, divide, multiply } = require('mathjs');
 const config = require('../config');
@@ -27,20 +22,18 @@ module.exports = async (basePrice) => {
   // starting percentage down from basePrice to place limit orders
   const dropPoints = process.env.CPBB_REBUY_AT.split(',').map(p=>divide(Number(p), 100));
   // only set orders until they reach this threshold total
-  const maxFunds = Number(process.env.CPBB_REBUY_VOL);
-  let size = Number(process.env.CPBB_REBUY_SIZE);
-  const multiplier = Number(process.env.CPBB_REBUY_MULTIPLIER);
+  const maxFunds = Number(process.env.CPBB_REBUY_MAX);
+  const sizes = process.env.CPBB_REBUY_SIZE.split(',').map(s=>Number(s));
   let usedFunds = 0; // counter
   log.debug(
-    `REBUY: setting up to ${process.env.CPBB_REBUY_MAX} limit orders, up to $${maxFunds}, for ${size}${multiplier?` (x${multiplier})`:''} ${config.ticker} @ ${process.env.CPBB_REBUY_AT}% drops`
+    `REBUY: setting limit orders up to $${maxFunds}, for ${size} ${config.ticker} @ ${process.env.CPBB_REBUY_AT}% drops`
   );
   // place up to CPBB_REBUY_MAX limit orders
-  for (let i = 0; i < process.env.CPBB_REBUY_MAX; i++) {
+  for (let i = 0; i < sizes.length; i++) {
     let percentageDrop = dropPoints[i]; // e.g. -.5%, -1%, etc
+    let size = sizes[i];
     let price = add(basePrice, multiply(basePrice, percentageDrop)).toFixed(2);
-    // if we are multiplying the btc size each drop point, do so (only if not the first order)
-    if(multiplier && i) size = multiply(size, multiplier);
-    let funds = multiply(Number(size), price);
+    let funds = multiply(size, price);
     if(add(usedFunds, funds) > maxFunds){
       break; // stop processing
     }

--- a/lib/rebuys.post.js
+++ b/lib/rebuys.post.js
@@ -1,0 +1,66 @@
+/**
+ * Handles rebuying after a sell by setting up limit orders on the books using special config vars
+ * Sample env config:
+// should the engine only create and manage the limit orders and not make normal accumulation trades
+// useful for testing this feature
+CPBB_REBUY_ONLY: true,
+// place up to 2 maker limit orders on the books after a sell action
+CPBB_REBUY_MAX: 2,
+// maximum dollar value consumed by limit order placements
+CPBB_REBUY_VOL: 50,
+// minimum order is in BTC (.0001, which is $5 at $50K, or $2 at $20K)
+// rebuy logic will place up to CPBB_REBUY_MAX orders at this size until CPBB_REBUY_VOL is reached
+CPBB_REBUY_SIZE: .0001,
+// should the size be doubled at each percentage drop (.e.g .0001, .0002)?
+// acts as a multiplier if you want to just go to .00015 with 1.5
+CPBB_REBUY_MULTIPLIER: 2,
+// -0.5% intervals (e.g. -0.05%, -0.01%, -0.15%, -0.2%, -0.25%, -0.3%, -0.35%, -0.4%)
+CPBB_REBUY_AT: -0.05,
+ */
+const { add, divide, multiply } = require('mathjs');
+const config = require('../config');
+const fs = require('fs');
+const log = require("./log");
+const memory = require("../data/memory");
+const processOrder = require('./process.order');
+module.exports = async (basePrice) => {
+  // starting percentage down from basePrice to place limit orders
+  const baseDrop = divide(Number(process.env.CPBB_REBUY_AT), 100);
+  // only set orders until they reach this threshold total
+  const maxFunds = Number(process.env.CPBB_REBUY_VOL);
+  let size = Number(process.env.CPBB_REBUY_SIZE);
+  const multiplier = process.env.CPBB_REBUY_MULTIPLIER;
+  let usedFunds = 0; // counter
+  log.debug(
+    `REBUY: setting up to ${process.env.CPBB_REBUY_MAX} limit orders, up to $${maxFunds}, for ${size}${multiplier?` (x${multiplier})`:''} ${config.ticker} @ ${process.env.CPBB_REBUY_AT}% drops`
+  );
+  // place up to CPBB_REBUY_MAX limit orders
+  for (let i = 0; i < process.env.CPBB_REBUY_MAX; i++) {
+    let percentageDrop = multiply(baseDrop, i + 1); // e.g. -.5%, -1%, etc
+    let price = add(basePrice, multiply(basePrice, percentageDrop)).toFixed(2);
+    // if we are multiplying the btc size each drop point, do so (only if not the first order)
+    if(multiplier && i) size = multiply(size, multiplier);
+    let funds = multiply(Number(size), price);
+    if(add(usedFunds, funds) > maxFunds){
+      break; // stop processing
+    }
+    usedFunds = add(usedFunds, funds);
+    let order = {
+      funds,
+      price,
+      size,
+      type: 'limit',
+    };
+    let orderResponse = await processOrder(order);
+    log.debug({ order, orderResponse });
+    memory.makerOrders.orders.push({
+      funds,
+      id: orderResponse.id,
+      price,
+      size
+    });
+  }
+  log.debug(`REBUY: set ${memory.makerOrders.orders.length} limit orders totalling $${usedFunds}`)
+  // save makerOrders to disk in case this process crashes
+  fs.writeFileSync(`${__dirname}/../data/maker.orders.json`, JSON.stringify(memory.makerOrders, null, 2));
+}

--- a/lib/rebuys.post.js
+++ b/lib/rebuys.post.js
@@ -25,9 +25,6 @@ module.exports = async (basePrice) => {
   const maxFunds = Number(process.env.CPBB_REBUY_MAX);
   const sizes = process.env.CPBB_REBUY_SIZE.split(',').map(s=>Number(s));
   let usedFunds = 0; // counter
-  log.debug(
-    `REBUY: setting limit orders up to $${maxFunds}, for ${size} ${config.ticker} @ ${process.env.CPBB_REBUY_AT}% drops`
-  );
   // place up to CPBB_REBUY_MAX limit orders
   for (let i = 0; i < sizes.length; i++) {
     let percentageDrop = dropPoints[i]; // e.g. -.5%, -1%, etc

--- a/run.btcusd.limit_only.config.js
+++ b/run.btcusd.limit_only.config.js
@@ -6,7 +6,7 @@ const apiKeys = require("./api.keys");
 module.exports = {
   apps: [
     {
-      name: "cpbb_btcusd",
+      name: "cpbb_btcusd_limit",
       script: ".",
       watch: ["*.js", "coinbase", "lib"],
       env: {
@@ -15,8 +15,8 @@ module.exports = {
         CPBB_APIKEY: apiKeys.CPBB_APIKEY,
         CPBB_APISEC: apiKeys.CPBB_APISEC,
         // VERBOSE: true,
-        // run at 5:03 am daily
-        CPBB_FREQ: "3 5 * * *",
+        // every hour at the 35 minute
+        CPBB_FREQ: "35 * * * *",
         CPBB_TICKER: "BTC",
         CPBB_CURRENCY: "USD",
         CPBB_VOL: 50, // $50 each day

--- a/run.btcusd.limit_only.config.js
+++ b/run.btcusd.limit_only.config.js
@@ -16,13 +16,11 @@ module.exports = {
         CPBB_APISEC: apiKeys.CPBB_APISEC,
         // VERBOSE: true,
         // every 2 minutes (for testing)
-        // NOTE: if you run this in a bear market, it can spend up to CPBB_VOL every 2 minutes!
+        // NOTE: if you run this in a bear market, it can spend up to CPBB_REBUY_MAX every 2 minutes!
         // this config example is just for testing!
         CPBB_FREQ: "*/2 * * * *",
         CPBB_TICKER: "BTC",
         CPBB_CURRENCY: "USD",
-        CPBB_VOL: 50, // $50 worth of limits always on the books (unless filled in interval)
-        CPBB_APY: 100, // sell if over 100% APY
         // should the engine only create and manage the limit orders and not make normal accumulation trades
         // useful for testing this feature
         // or for running a bot that only wants to accumulate an asset via dips

--- a/run.btcusd.limit_only.config.js
+++ b/run.btcusd.limit_only.config.js
@@ -15,8 +15,8 @@ module.exports = {
         CPBB_APIKEY: apiKeys.CPBB_APIKEY,
         CPBB_APISEC: apiKeys.CPBB_APISEC,
         // VERBOSE: true,
-        // every hour at the 35 minute
-        CPBB_FREQ: "35 * * * *",
+        // every 5 minutes
+        CPBB_FREQ: "*/2 * * * *",
         CPBB_TICKER: "BTC",
         CPBB_CURRENCY: "USD",
         CPBB_VOL: 50, // $50 each day
@@ -27,14 +27,18 @@ module.exports = {
         CPBB_REBUY_ONLY: true,
         // maximum dollar value consumed by limit order placements
         CPBB_REBUY_MAX: 50,
-        // minimum order is in BTC (.0001, which is $5 at $50K)
-        // minimum order is in ETH (.001, which is $5 at $5K)
-        // minimum order is in LTC (.01, which is $5 at $500)
+        // NOTE: as of 2021-02-22, Coinbase has the following minimum order sizes:
+        // BTC minimum order is .0001 ($5 at $50K)
+        // ETH minimum order is .001 ($5 at $5K)
+        // LTC minimum order is .01 ($5 at $500)
+        // DASH minimum order is .01 ($5 at $500)
+        // etc: try to make absurdly small limit orders via coinbase UI to get an error with the limit
+        // these could change in the future and allow you to make smaller size rebuy trades
         // rebuy logic will place up to  orders at this size until CPBB_REBUY_MAX is reached
         CPBB_REBUY_SIZE: ".0001,.0001,.0002,.0002,.0003,.0003,.0004,.0004,.0005,.0005",
         // rebuy at these percentage drop targets (-1%, -2%, etc)
         // note: you have to define at least the number of points in CPBB_REBUY_SIZE
-        CPBB_REBUY_AT: "-1,-2,-4,-8,-16,-20,-30,-40,-50,-80",
+        CPBB_REBUY_AT: "-.01,-2,-4,-5,-8,-10,-12,-25,-50,-80",
       },
     },
   ],

--- a/run.btcusd.limit_only.config.js
+++ b/run.btcusd.limit_only.config.js
@@ -1,3 +1,7 @@
+/**
+ * sample config that runs BTC-USD every 2 hours but only with posting LIMIT orders
+ * NO regular engine MAKER orders are performed
+ */
 const apiKeys = require("./api.keys");
 module.exports = {
   apps: [
@@ -14,13 +18,19 @@ module.exports = {
         CPBB_FREQ: "3 */2 * * *",
         CPBB_TICKER: "BTC",
         CPBB_CURRENCY: "USD",
-        CPBB_VOL: 10,
-        CPBB_APY: 5, // sell if over 5% APY
+        CPBB_VOL: 10, // $10
+        CPBB_APY: 10, // sell if over 10% APY
+        // should the engine only create and manage the limit orders and not make normal accumulation trades
+        // useful for testing this feature
+        // or for running a bot that only wants to accumulate an asset via dips
+        CPBB_REBUY_ONLY: true,
         // place up to 5 maker limit orders on the books after a sell action
         CPBB_REBUY_MAX: 5,
         // maximum dollar value consumed by limit order placements
         CPBB_REBUY_VOL: 10,
-        // minimum order is in BTC (.0001, which is $5 at $50K, or $2 at $20K)
+        // minimum order is in BTC (.0001, which is $5 at $50K)
+        // minimum order is in ETH (.001, which is $5 at $5K)
+        // minimum order is in LTC (.01, which is $5 at $500)
         // rebuy logic will place up to CPBB_REBUY_MAX orders at this size until CPBB_REBUY_VOL is reached
         CPBB_REBUY_SIZE: .0001,
         // should the size be doubled (or otherwise multiplied) at each percentage drop (.e.g .0001, .0002)?

--- a/run.btcusd.limit_only.config.js
+++ b/run.btcusd.limit_only.config.js
@@ -25,20 +25,15 @@ module.exports = {
         // useful for testing this feature
         // or for running a bot that only wants to accumulate an asset via dips
         CPBB_REBUY_ONLY: true,
-        // place up to 5 maker limit orders on the books after a sell action
-        CPBB_REBUY_MAX: 5,
         // maximum dollar value consumed by limit order placements
-        CPBB_REBUY_VOL: 50,
+        CPBB_REBUY_MAX: 50,
         // minimum order is in BTC (.0001, which is $5 at $50K)
         // minimum order is in ETH (.001, which is $5 at $5K)
         // minimum order is in LTC (.01, which is $5 at $500)
-        // rebuy logic will place up to CPBB_REBUY_MAX orders at this size until CPBB_REBUY_VOL is reached
-        CPBB_REBUY_SIZE: .0001,
-        // should the size be doubled (or otherwise multiplied) at each percentage drop (.e.g .0001, .0002)?
-        // acts as a multiplier if you want to just go to .00015 with 1.5
-        CPBB_REBUY_MULTIPLIER: 1.5,
+        // rebuy logic will place up to  orders at this size until CPBB_REBUY_MAX is reached
+        CPBB_REBUY_SIZE: ".0001,.0001,.0002,.0002,.0003,.0003,.0004,.0004,.0005,.0005",
         // rebuy at these percentage drop targets (-1%, -2%, etc)
-        // note: you have to define at least the number of points in CPBB_REBUY_MAX
+        // note: you have to define at least the number of points in CPBB_REBUY_SIZE
         CPBB_REBUY_AT: "-1,-2,-4,-8,-16,-20,-30,-40,-50,-80",
       },
     },

--- a/run.btcusd.limit_only.config.js
+++ b/run.btcusd.limit_only.config.js
@@ -15,11 +15,12 @@ module.exports = {
         CPBB_APIKEY: apiKeys.CPBB_APIKEY,
         CPBB_APISEC: apiKeys.CPBB_APISEC,
         // VERBOSE: true,
-        CPBB_FREQ: "3 */2 * * *",
+        // run at 5:03 am daily
+        CPBB_FREQ: "3 5 * * *",
         CPBB_TICKER: "BTC",
         CPBB_CURRENCY: "USD",
-        CPBB_VOL: 10, // $10
-        CPBB_APY: 10, // sell if over 10% APY
+        CPBB_VOL: 50, // $50 each day
+        CPBB_APY: 100, // sell if over 100% APY
         // should the engine only create and manage the limit orders and not make normal accumulation trades
         // useful for testing this feature
         // or for running a bot that only wants to accumulate an asset via dips
@@ -27,7 +28,7 @@ module.exports = {
         // place up to 5 maker limit orders on the books after a sell action
         CPBB_REBUY_MAX: 5,
         // maximum dollar value consumed by limit order placements
-        CPBB_REBUY_VOL: 10,
+        CPBB_REBUY_VOL: 50,
         // minimum order is in BTC (.0001, which is $5 at $50K)
         // minimum order is in ETH (.001, which is $5 at $5K)
         // minimum order is in LTC (.01, which is $5 at $500)
@@ -35,10 +36,10 @@ module.exports = {
         CPBB_REBUY_SIZE: .0001,
         // should the size be doubled (or otherwise multiplied) at each percentage drop (.e.g .0001, .0002)?
         // acts as a multiplier if you want to just go to .00015 with 1.5
-        CPBB_REBUY_MULTIPLIER: 2,
+        CPBB_REBUY_MULTIPLIER: 1.5,
         // rebuy at these percentage drop targets (-1%, -2%, etc)
         // note: you have to define at least the number of points in CPBB_REBUY_MAX
-        CPBB_REBUY_AT: "-1,-2,-4,-8,-16",
+        CPBB_REBUY_AT: "-1,-2,-4,-8,-16,-20,-30,-40,-50,-80",
       },
     },
   ],

--- a/run.btcusd.limit_only.config.js
+++ b/run.btcusd.limit_only.config.js
@@ -15,11 +15,13 @@ module.exports = {
         CPBB_APIKEY: apiKeys.CPBB_APIKEY,
         CPBB_APISEC: apiKeys.CPBB_APISEC,
         // VERBOSE: true,
-        // every 5 minutes
+        // every 2 minutes (for testing)
+        // NOTE: if you run this in a bear market, it can spend up to CPBB_VOL every 2 minutes!
+        // this config example is just for testing!
         CPBB_FREQ: "*/2 * * * *",
         CPBB_TICKER: "BTC",
         CPBB_CURRENCY: "USD",
-        CPBB_VOL: 50, // $50 each day
+        CPBB_VOL: 50, // $50 worth of limits always on the books (unless filled in interval)
         CPBB_APY: 100, // sell if over 100% APY
         // should the engine only create and manage the limit orders and not make normal accumulation trades
         // useful for testing this feature

--- a/run.btcusd.rebuy.config.js
+++ b/run.btcusd.rebuy.config.js
@@ -16,6 +16,7 @@ module.exports = {
         CPBB_CURRENCY: "USD",
         CPBB_VOL: 10,
         CPBB_APY: 10, // sell if over 10% APY
+
         // MAKER REBUY CONFIG
         // The below section will create the following maker orders after a sell
         // .0001 BTC @ price -1% (as long as bitcoin is under $100K)
@@ -24,20 +25,13 @@ module.exports = {
         // .0008 BTC @ price -8% (but only if this doesn't bust the $10 max)
         // .0016 BTC @ price -16% (but only if this doesn't bust the $10 max)
 
-        // rebuy logic will place up to CPBB_REBUY_MAX orders
-        // at this size (multiplied by CPBB_REBUY_MULTIPLIER) until CPBB_REBUY_VOL is reached
-        // using CPBB_REBUY_AT as each drop point
-        // place up to 10 maker limit orders on the books after a sell action
-        CPBB_REBUY_MAX: 10,
         // maximum dollar value consumed by limit order placements
-        CPBB_REBUY_VOL: 10,
+        CPBB_REBUY_MAX: 10,
         // minimum order is in BTC (.0001, which is $5 at $50K)
-        CPBB_REBUY_SIZE: .0001,
-        // what should the size be multiplied by each drop point (1 means keep it stable),
-        // 2 would set an order of .0001, then .0002, then .0004, etc
-        CPBB_REBUY_MULTIPLIER: 1,
+        // rebuy logic will place up to  orders at this size until CPBB_REBUY_MAX is reached
+        CPBB_REBUY_SIZE: ".0001,.0001,.0002,.0002,.0003,.0003,.0004,.0004,.0005,.0005",
         // rebuy at these percentage drop targets (-1%, -2%, etc)
-        // note: you have to define at least the number of points in CPBB_REBUY_MAX
+        // note: you have to define at least the number of points in CPBB_REBUY_SIZE
         CPBB_REBUY_AT: "-1,-2,-4,-8,-16,-20,-30,-40,-50,-80",
       },
     },

--- a/run.btcusd.rebuy.config.js
+++ b/run.btcusd.rebuy.config.js
@@ -11,7 +11,7 @@ module.exports = {
         CPBB_APIKEY: apiKeys.CPBB_APIKEY,
         CPBB_APISEC: apiKeys.CPBB_APISEC,
         // VERBOSE: true,
-        CPBB_FREQ: "3 */2 * * *",
+        CPBB_FREQ: "28 */2 * * *",
         CPBB_TICKER: "BTC",
         CPBB_CURRENCY: "USD",
         CPBB_VOL: 10,

--- a/run.btcusd.rebuy.config.js
+++ b/run.btcusd.rebuy.config.js
@@ -20,10 +20,11 @@ module.exports = {
         // MAKER REBUY CONFIG
         // The below section will create the following maker orders after a sell
         // .0001 BTC @ price -1% (as long as bitcoin is under $100K)
-        // .0002 BTC @ price -2% (but only if this doesn't bust the $10 max)
-        // .0004 BTC @ price -4% (but only if this doesn't bust the $10 max)
-        // .0008 BTC @ price -8% (but only if this doesn't bust the $10 max)
-        // .0016 BTC @ price -16% (but only if this doesn't bust the $10 max)
+        // .0001 BTC @ price -2% (but only if this doesn't bust the $10 max)
+        // .0002 BTC @ price -4% (but only if this doesn't bust the $10 max)
+        // .0002 BTC @ price -8% (but only if this doesn't bust the $10 max)
+        // .0003 BTC @ price -16% (but only if this doesn't bust the $10 max)
+        // etc...
 
         // maximum dollar value consumed by limit order placements
         CPBB_REBUY_MAX: 10,

--- a/run.btcusd.rebuy.config.js
+++ b/run.btcusd.rebuy.config.js
@@ -15,20 +15,30 @@ module.exports = {
         CPBB_TICKER: "BTC",
         CPBB_CURRENCY: "USD",
         CPBB_VOL: 10,
-        CPBB_APY: 5, // sell if over 5% APY
-        // place up to 5 maker limit orders on the books after a sell action
-        CPBB_REBUY_MAX: 5,
+        CPBB_APY: 10, // sell if over 10% APY
+        // MAKER REBUY CONFIG
+        // The below section will create the following maker orders after a sell
+        // .0001 BTC @ price -1% (as long as bitcoin is under $100K)
+        // .0002 BTC @ price -2% (but only if this doesn't bust the $10 max)
+        // .0004 BTC @ price -4% (but only if this doesn't bust the $10 max)
+        // .0008 BTC @ price -8% (but only if this doesn't bust the $10 max)
+        // .0016 BTC @ price -16% (but only if this doesn't bust the $10 max)
+
+        // rebuy logic will place up to CPBB_REBUY_MAX orders
+        // at this size (multiplied by CPBB_REBUY_MULTIPLIER) until CPBB_REBUY_VOL is reached
+        // using CPBB_REBUY_AT as each drop point
+        // place up to 10 maker limit orders on the books after a sell action
+        CPBB_REBUY_MAX: 10,
         // maximum dollar value consumed by limit order placements
         CPBB_REBUY_VOL: 10,
-        // minimum order is in BTC (.0001, which is $5 at $50K, or $2 at $20K)
-        // rebuy logic will place up to CPBB_REBUY_MAX orders at this size until CPBB_REBUY_VOL is reached
+        // minimum order is in BTC (.0001, which is $5 at $50K)
         CPBB_REBUY_SIZE: .0001,
-        // should the size be doubled (or otherwise multiplied) at each percentage drop (.e.g .0001, .0002)?
-        // acts as a multiplier if you want to just go to .00015 with 1.5
-        CPBB_REBUY_MULTIPLIER: 2,
+        // what should the size be multiplied by each drop point (1 means keep it stable),
+        // 2 would set an order of .0001, then .0002, then .0004, etc
+        CPBB_REBUY_MULTIPLIER: 1,
         // rebuy at these percentage drop targets (-1%, -2%, etc)
         // note: you have to define at least the number of points in CPBB_REBUY_MAX
-        CPBB_REBUY_AT: "-1,-2,-4,-8,-16",
+        CPBB_REBUY_AT: "-1,-2,-4,-8,-16,-20,-30,-40,-50,-80",
       },
     },
   ],

--- a/run.btcusd.rebuy.config.js
+++ b/run.btcusd.rebuy.config.js
@@ -1,0 +1,33 @@
+const apiKeys = require("./api.keys");
+module.exports = {
+  apps: [
+    {
+      name: "cpbb_btcusd",
+      script: ".",
+      watch: ["*.js", "coinbase", "lib"],
+      env: {
+        NODE_ENV: "production",
+        CPBB_APIPASS: apiKeys.CPBB_APIPASS,
+        CPBB_APIKEY: apiKeys.CPBB_APIKEY,
+        CPBB_APISEC: apiKeys.CPBB_APISEC,
+        // VERBOSE: true,
+        CPBB_FREQ: "3 */2 * * *",
+        CPBB_TICKER: "BTC",
+        CPBB_CURRENCY: "USD",
+        CPBB_VOL: 10,
+        CPBB_APY: 5, // sell if over 5% APY
+        // place up to 5 maker limit orders on the books after a sell action
+        CPBB_REBUY_MAX: 5,
+        // maximum dollar value consumed by limit order placements
+        CPBB_REBUY_VOL: 10,
+        // minimum order is in BTC (.0001, which is $5 at $50K, or $2 at $20K)
+        // rebuy logic will place up to CPBB_REBUY_MAX orders at this size until CPBB_REBUY_VOL is reached
+        CPBB_REBUY_SIZE: .0001,
+        // should the size be doubled at each percentage drop (.e.g .0001, .0002)?
+        // acts as a multiplier if you want to just go to .00015 with 1.5
+        CPBB_REBUY_MULTIPLIER: 2,
+        CPBB_REBUY_AT: -1,
+      },
+    },
+  ],
+};


### PR DESCRIPTION
Cleaned up version of https://github.com/jasonedison/coinbase_position_builder_bot/pull/2

new env configs:
```

// MAKER REBUY CONFIG
// The below section will create the following maker orders after a sell
// .0001 BTC @ price -1% (but only if this doesn't bust the $100 max)
// .0001 BTC @ price -2% (but only if this doesn't bust the $100 max)
// .0002 BTC @ price -4% (but only if this doesn't bust the $100 max)
// .0002 BTC @ price -8% (but only if this doesn't bust the $100 max)
// .0003 BTC @ price -16% (but only if this doesn't bust the $100 max)
// etc...

// should the engine only create and manage the limit orders and not make normal accumulation trades
// useful for testing this feature
// or for running a bot that only wants to accumulate an asset via dips
CPBB_REBUY_ONLY: false,

// maximum dollar value consumed by limit order placements
CPBB_REBUY_MAX: 100, // spend up to $100 posting limit rebuys
// minimum order is in BTC (.0001, which is $5 at $50K)
// rebuy logic will place up to  orders at this size until CPBB_REBUY_MAX is reached
CPBB_REBUY_SIZE: ".0001,.0001,.0002,.0002,.0003,.0003,.0004,.0004,.0005,.0005",
// rebuy at these percentage drop targets (-1%, -2%, etc)
// note: you have to define at least the number of points in CPBB_REBUY_SIZE
CPBB_REBUY_AT: "-1,-2,-4,-8,-16,-20,-30,-40,-50,-80",
```

When enabled with these new config options the engine now does the following:

1. check for existing limit orders on the books
2. add any filled limit orders to the history
3. delete any unfilled limit orders
4. calculate and run new action
5. if action was to sell, create new set of limit orders to rebuy


# Testing it
This is running a tight 2 minute iteration of the `run.btcusd.limit_only.config.js` config to make sure it can post and clear rebuys and also trigger a rebuy within the 2 minutes (a -.01% drop) and save it to the log:

<img width="1285" alt="Screen Shot 2021-02-21 at 10 54 11 PM" src="https://user-images.githubusercontent.com/70015/108736868-db91d600-74e6-11eb-8476-40cc7b93be1e.png">
