### PR TITLE
Rebuy Rebuild

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,11 @@
+# 2.5.0
+- New configuration of `CPBB_REBUY_REBUILD`, which is a number of active limit orders on the books to consider the set ready for a rebuild based on the existing rebuy SIZE/AT config.
+- NOTE: this is only useful if you have `CPBB_REBUY_CANCEL` set to something other than 0, where limit orders can pile up over many runs. By default, limit orders are canceled on the next cron.
+- If `CPBB_REBUY_REBUILD` is triggered, existing limit orders will be canceled and new orders will be built from the highest price of the order set, and using the total `funds` from the limit orders on the books. For example, if you normally put $50 into rebuy orders, but the rebuy limits have piled up through several sell operations, you might have 20 limit orders worth $120 on the books, all accumulated in one region. Setting `CPBB_REBUY_REBUILD` to 20 (or less) will cause the next run to cancel these limit orders and build a new set of limit orders up to $120, up to the number of drop points configured in `CPBB_REBUY_AT`
+- Resuming checking each limit order to be sure they haven't been manually deleted  
+- Removing 404 limit orders from tracking (limit orders can be manually deleted or deleted by Coinbase system maintenance)
+- Correcting rate limiting issues by sleeping between rebuy checks and posts
+
 # 2.4.0
 - Added new configuration to support leaving limit rebuy orders on the books longer
   - new CBPP_REBUY_CANCEL environmental variable is the minimum number of minutes you would like the order to remain on the books (note that the cancelation will only occur on the next interval so if you set this to 5 minutes but have a cron job timer set to every hour, the limits will cancel after 1 hour)

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -5,6 +5,7 @@
 - Resuming checking each limit order to be sure they haven't been manually deleted  
 - Removing 404 limit orders from tracking (limit orders can be manually deleted or deleted by Coinbase system maintenance)
 - Correcting rate limiting issues by sleeping between rebuy checks and posts
+- New Tool: `tools/create.history.js` - goes through entire coinbase pro fill history for a trading pair and generates a history file from that data. NOTE: if you bought/sold crypto via Coinbase and moved in in and out of Coinbase Pro, you can end up with negative holdings at points in the history file because it only has access to the Coinbase Pro side.
 
 # 2.4.0
 - Added new configuration to support leaving limit rebuy orders on the books longer

--- a/README.md
+++ b/README.md
@@ -146,7 +146,16 @@ CPBB_REBUY_AT: "-2,-4,-6,-8,-10,-12,-15,-25,-50,-80",
 // set to 0 or remove ENV var to have default behavior of canceling on the next
 // action timer
 // below is a config to leave the order for a minimum time of 3 days
-CPBB_REBUY_CANCEL: 60 * 24 * 3
+CPBB_REBUY_CANCEL: 60 * 24 * 3,
+// if there are twelve unfilled limit orders remaining on the books, expire them
+// and rebuild the limit order set immediately using the sum total of funds
+// used for all the limit orders that existed, starting with the price at the highest limit value
+// using the rebuy config to create new orders
+// NOTE: if you use this setting, it is recommended that you set it higher than
+// the number of items in your CPBB_REBUY_AT config so it doesn't excessively rebuild
+// the same oders over and over
+// NOTE: this feature only matters if you are using a non-zero CPBB_REBUY_CANCEL config
+CPBB_REBUY_REBUILD: 12
 ```
 
 The above config will cause the engine to attempt to set up to $50 worth of limit orders for the asset after each `sell` action. The orders will be placed as .0001 @ -.01% drop (very soon), .0001 @ -2% drop, etc until the $50 spending threshold is met.

--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ CPBB_REBUY_CANCEL: 60 * 24 * 3,
 // the number of items in your CPBB_REBUY_AT config so it doesn't excessively rebuild
 // the same oders over and over
 // NOTE: this feature only matters if you are using a non-zero CPBB_REBUY_CANCEL config
+// NOTE: enabling this feature also sets new created_at timestamps for limit orders so the expiration is continuously pushed out until they are filled
 CPBB_REBUY_REBUILD: 12
 ```
 

--- a/README.md
+++ b/README.md
@@ -296,6 +296,20 @@ To correct this, I've added a manual log entry tool. In order to use this, you w
 node addLog.js BTC USD 50 20 2020-11-26T16:35:00.706Z 16915.52 0.00295586
 ```
 
+## Build Complete History from Coinbase Pro Fills
+
+If you want to add all manual activity to the history file, you can generate a new history file using all of the Coinbase Pro data. This only looks at Coinbase Pro so if you moved funds in and out of that service (even to Coinbase), there can be negative balances appearing in the Holdings section of the history. If you bought coins elsewhere and moved them into Coinbase Pro, you will have possible sells that have no buy history associated with them.
+
+```
+cd tools;
+CPBB_TICKER=BTC CPBB_CURRENCY=USD CPBB_APY=150 CPBB_SINCE=2015-01-01 node create.history.js
+```
+or to use a cached fills history file:
+```
+cd tools;
+CPBB_TICKER=BTC CPBB_CURRENCY=USD CPBB_APY=150 CPBB_SINCE=2015-01-01 CPBB_FILLS=../data/fills_BTC-USD.json node create.history.js
+```
+
 # Disclaimer
 This software is provided "as is", without warranty of any kind, express or implied, including but not limited to the warranties of merchantability, fitness for a particular purpose and non-infringement. In no event shall the authors, copyright holders, or Coinbase Inc. be liable for any claim, damages or other liability, whether in an action of contract, tort or otherwise, arising from, out of or in connection with the software or the use or other dealings in the software.
 

--- a/coinbase/delete.order.js
+++ b/coinbase/delete.order.js
@@ -1,15 +1,14 @@
 // https://docs.pro.coinbase.com/#cancel-an-order
 
+const config = require('../config');
 const request = require("./cb.request");
 
 module.exports = async (id) => {
-  if (process.env.CPBB_DRY_RUN) {
-    return true;
-  }
-  const { json } = await request({
+  if (config.dry) return true;
+  const response = await request({
     requestPath: `/orders/${id}`,
     method: "DELETE"
   });
 
-  return json;
+  return response ? response.json : undefined;
 };

--- a/coinbase/get.order.js
+++ b/coinbase/get.order.js
@@ -22,8 +22,9 @@ module.exports = async (order) => {
       method: "GET",
     };
     log.debug(opts);
-    const { json } = await request(opts);
-    log.debug(json);
+    const response = await request(opts);
+    log.debug(response);
+    const json = response ? response.json : response;
     // NOTE: we allow limit orders to be unsettled and even not found (sometimes limits get purged due to maintenance or other conditions)
     if (order.type === 'market' && (
       !json ||

--- a/coinbase/http.request.js
+++ b/coinbase/http.request.js
@@ -17,6 +17,9 @@ module.exports = (params) => {
           log.error('failed to parse response from API', e)
           reject(e);
         }
+        if (res.statusCode === 429) {
+          log.error('Error 429: rate limited. Please file an issue here: https://github.com/jasonedison/coinbase_position_builder_bot/issues');
+        }
         if (res.statusCode < 200 || res.statusCode >= 300) {
           if (json && json.message === "invalid signature") {
             log.error(

--- a/coinbase/order.js
+++ b/coinbase/order.js
@@ -1,12 +1,13 @@
 // https://docs.pro.coinbase.com/?javascript#place-a-new-order
 
 const { divide, multiply } = require("../lib/math");
+const config = require('../config');
 const memory = require("../lib/memory");
 const numFix = require("../lib/number.fix");
 const request = require("./cb.request");
 
 module.exports = async (opts) => {
-  if (process.env.CPBB_DRY_RUN) {
+  if (config.dry) {
     // fake out a .002 fee subtraction
     const converted = multiply(opts.funds, 0.998);
     return {
@@ -21,10 +22,10 @@ module.exports = async (opts) => {
       settled: true,
     };
   }
-  const { json } = await request({
+  const response = await request({
     requestPath: "/orders",
     method: "POST",
     body: opts,
   });
-  return json;
+  return response ? response.json : response;
 };

--- a/config.js
+++ b/config.js
@@ -2,10 +2,12 @@ const fs = require("fs");
 const log = require('./lib/log');
 const pjson = require("./package");
 
+const { divide } = require('./lib/math');
 const config = {
   api: process.env.CPBB_TEST
     ? "https://api-public.sandbox.pro.coinbase.com"
     : "https://api.pro.coinbase.com",
+  dry: process.env.CPBB_DRY_RUN === "true",
   // default run once per 12 hours at the 5th minute (crontab syntax)
   // testing mode will run every minute
   freq: process.env.CPBB_TEST
@@ -17,7 +19,12 @@ const config = {
   apy: Number(process.env.CPBB_APY || 15) / 100,
   rebuy: {
     // ms after limit order placed before it is able to be canceled due to not filling
-    cancel: Number(process.env.CPBB_REBUY_CANCEL || 0) * 60000
+    cancel: Number(process.env.CPBB_REBUY_CANCEL || 0) * 60000,
+    drops: (process.env.CPBB_REBUY_AT || '').split(',').map(p => divide(p, 100)),
+    max: Number(process.env.CPBB_REBUY_MAX || 0),
+    only: process.env.CPBB_REBUY_ONLY === 'true',
+    rebuild: Number(process.env.CPBB_REBUY_REBUILD || 0),
+    sizes: (process.env.CPBB_REBUY_SIZE || '').split(',').map(s => Number(s))
   },
   // if the trading pair ordering doesn't exist (e.g. BTC-LTC)
   // we have to reverse our logic to run from the trading pair that does exist (e.g. LTC-BTC)

--- a/config.js
+++ b/config.js
@@ -20,11 +20,11 @@ const config = {
   rebuy: {
     // ms after limit order placed before it is able to be canceled due to not filling
     cancel: Number(process.env.CPBB_REBUY_CANCEL || 0) * 60000,
-    drops: (process.env.CPBB_REBUY_AT || '').split(',').map(p => divide(p, 100)),
+    drops: (process.env.CPBB_REBUY_AT || '').split(',').map(p => p ? divide(p, 100) : null).filter(i => i),
     max: Number(process.env.CPBB_REBUY_MAX || 0),
     only: process.env.CPBB_REBUY_ONLY === 'true',
     rebuild: Number(process.env.CPBB_REBUY_REBUILD || 0),
-    sizes: (process.env.CPBB_REBUY_SIZE || '').split(',').map(s => Number(s))
+    sizes: (process.env.CPBB_REBUY_SIZE || '').split(',').map(s => s ? Number(s) : null).filter(i => i)
   },
   // if the trading pair ordering doesn't exist (e.g. BTC-LTC)
   // we have to reverse our logic to run from the trading pair that does exist (e.g. LTC-BTC)

--- a/index.js
+++ b/index.js
@@ -24,16 +24,16 @@ const job = new CronJob(config.freq, action);
   }
   log.now(
     `🤖 Position Builder Bot ${config.pjson.version}, ${config.api
-    } in ${process.env.CPBB_DRY_RUN ? "DRY RUN" : "LIVE"} mode, ${config.vol
+    } in ${config.dry ? "DRY RUN" : "LIVE"} mode, ${config.vol
     } $${config.currency} ➡️  $${config.ticker} @ cron(${config.freq
-    }), ${config.apy * 100}% APY, ${process.env.VERBOSE ? `verbose` : 'ledger'} logging`
+    }), ${config.apy * 100}% APY, ${process.env.VERBOSE === 'true' ? `verbose logging` : ''}`
   );
-  if (process.env.CPBB_REBUY_AT) {
+  if (config.rebuy.drops) {
     const sizes = process.env.CPBB_REBUY_SIZE.split(',');
     const drops = process.env.CPBB_REBUY_AT.split(',');
-    log.now(`💵 REBUY up to $${process.env.CPBB_REBUY_MAX} of ${config.ticker}: ${sizes.map((s, i) => `${s}@${drops[i]}%`).join(', ')}`);
+    log.now(`💵 REBUY up to $${config.rebuy.max} of ${config.ticker}: ${sizes.map((s, i) => `${s}@${drops[i]}%`).join(', ')}`);
   }
-  if (process.env.CPBB_REBUY_ONLY === 'true') {
+  if (config.rebuy.only) {
     // this mode says "I want to buy this asset, but only when it's flashing downward during the timing interval"
     log.now(`${config.productID} set to REBUY ONLY MODE (will not create market taker trades, only limit orders at drops)`);
   }
@@ -54,7 +54,7 @@ const job = new CronJob(config.freq, action);
   log.now(`🏦 $${config.currency} account loaded with ${memory.account.available}`);
 
   // immediate kick off (testing mode)
-  if (process.env.CPBB_TEST || process.env.CPBB_DRY_RUN) action();
+  if (process.env.CPBB_TEST || config.dry) action();
 
   // start the cronjob
   job.start();

--- a/lib/action.js
+++ b/lib/action.js
@@ -29,7 +29,7 @@ module.exports = async (opts) => {
   ticker.price = memory.price;
   log.debug("ticker", ticker);
 
-  if (process.env.CPBB_REBUY_ONLY === 'true') {
+  if (config.rebuy.only) {
     await postRebuys(ticker.price);
     return;
   }
@@ -60,7 +60,7 @@ module.exports = async (opts) => {
   action.price = divide(response.executed_value, response.filled_size);
 
   // if configured to add limit rebuy orders with the sold profits, do so now
-  if (process.env.CPBB_REBUY_MAX && action.funds < 0) { // just sold
+  if (config.rebuy.max && action.funds < 0) { // just sold
     // get the real executed price (not the value from the ticker request)
     await postRebuys(action.price);
   }

--- a/lib/calculate.action.js
+++ b/lib/calculate.action.js
@@ -33,7 +33,7 @@ module.exports = async ({ dateOverride, forceBuy, price, type, volOverride }) =>
   action.diff = subtract(action.value, action.target);
   // simply, if our account value is above the target, sell, else buy
   // the `funds` is our market buy/sell amount in the base currency
-  const tradeValue = process.env.CPBB_LIQUIDATE ? action.value : vol;
+  const tradeValue = vol;
   // in the case of a limit order that was filled, we are forcing the calculation to have already bought (can't calc a sell)
   action.funds = forceBuy ? tradeValue : (action.diff > 0 ? tradeValue * -1 : tradeValue);
   action.endValue = add(action.value, action.funds);

--- a/lib/log.output.js
+++ b/lib/log.output.js
@@ -6,7 +6,7 @@ const moment = require('moment');
 module.exports = (logData) => {
   const currentHolding = logData.Holding + logData.Shares;
   const emoji =
-    (process.env.CPBB_DRY_RUN ? "🚫 " : "") + (logData.Funds > 0 ? "💸" : "🤑");
+    (config.dry ? "🚫 " : "") + (logData.Funds > 0 ? "💸" : "🤑");
 
   const costBasis = logData.TotalInput ? divide(logData.TotalInput, currentHolding) : 0;
   const liquidBasis = logData.TotalInput ? divide(subtract(logData.TotalInput, logData.Realized), currentHolding).toFixed(2) : 0;

--- a/lib/math.js
+++ b/lib/math.js
@@ -6,16 +6,6 @@
  */
 const { number, bignumber, add, subtract, multiply, divide } = require('mathjs');
 
-// vanilla JS (holding for posterity)
-// const precision = 10000000000;
-// const toInt = (v) => {
-//   return Number(v) * precision;
-// }
-// const toFloat = (v) => {
-//   return v / precision;
-// }
-// add: (a, b) => toFloat(toInt(a) + toInt(b)),
-
 module.exports = {
   add: (a, b) => number(add(bignumber(a), bignumber(b))),
   subtract: (a, b) => number(subtract(bignumber(a), bignumber(b))),

--- a/lib/rebuys.check.js
+++ b/lib/rebuys.check.js
@@ -1,14 +1,23 @@
-const { add, divide } = require('./math');
+const { add, divide, multiply } = require('./math');
 const config = require('../config');
 const calculateAction = require('./calculate.action');
 const deleteOrder = require("../coinbase/delete.order");
 const fs = require('fs');
-const getFills = require('../coinbase/get.fills');
+// const getFills = require('../coinbase/get.fills');
 const getOrder = require("../coinbase/get.order");
 const log = require("./log");
 const memory = require("./memory");
 const moment = require('moment');
 const saveLog = require("./log.save");
+const sleep = require('./sleep');
+const postRebuys = require('./rebuys.post');
+
+const cancelOrder = async (order) => {
+  log.now(`🚫 canceled limit order ${order.id} for ${order.size} ${config.ticker} @ ${order.price} = $${order.funds}`);
+  await deleteOrder(order.id);
+  memory.makerOrders.orders = memory.makerOrders.orders.filter(o => o.id !== order.id);
+};
+
 module.exports = async () => {
   // check to see if any filled and add them to the ledger if they have
   // cancel any others (so we have a clean slate)
@@ -16,18 +25,24 @@ module.exports = async () => {
   const pendingOrders = memory.makerOrders.orders.filter(o => o.pair === config.productID);
 
   // get recent fills since the first limit order we have on record
-  const fills = await getFills({ since: pendingOrders[0].created_at });
+  // const fills = await getFills({ since: pendingOrders[0].created_at });
 
+  const remaining = [];
   for (let i = 0; i < pendingOrders.length; i++) {
     let order = pendingOrders[i];
     log.debug(`checking order`, order);
-    let filled = fills.find(f => f.order_id === order.id);
+    let response = await getOrder(order);
+    // let filled = fills.find(f => f.order_id === order.id);
 
-    // it's possible that the limit order was only partially filled
-    // and is not yet settled. In that case, we will leave it alone
-    if (filled && filled.settled) {
+    if (!response) {
+      log.now(`🗑️ limit order ${order.id} not found (must have been deleted manually or through Coinbase maintenance), removing from tracking db.`);
+      memory.makerOrders.orders = memory.makerOrders.orders.filter(o => o.id !== order.id);
+    } else if (response && response.settled) {
+      // it's possible that the limit order was only partially filled
+      // and is not yet settled. In that case, we will leave it alone
+
       // get order status with done_at time (for some reason not returned in fills api)
-      let response = await getOrder(order);
+      // let response = await getOrder(order);
       // add it to the history
       // and set the funding value to the amount that was truly transacted
       let funds = add(response.executed_value, response.fill_fees);
@@ -50,18 +65,40 @@ module.exports = async () => {
     } else {
       const killAfter = order.created_at ? new Date(order.created_at).getTime() + config.rebuy.cancel : new Date().getTime() - config.rebuy.cancel;
       const now = new Date().getTime();
-      const remaining = killAfter - now;
+      const timeLeft = killAfter - now;
       if (killAfter <= now) {
         // delete the order from the books (it had its chance)
-        log.now(`🚫 canceled limit order ${order.id} for ${order.size} ${config.ticker} @ ${order.price} = $${order.funds}`);
-        deleteOrder(order.id); // no need to await
-        memory.makerOrders.orders = memory.makerOrders.orders.filter(o => o.id !== order.id);
+        await cancelOrder(order);
       } else {
-        log.now(`⏰ limit order ${order.id} remains for ${order.size} ${config.ticker} @ ${order.price} = $${order.funds} | expires ${moment.duration(remaining, 'milliseconds').humanize()}`);
+        log.now(`⏰ limit ${order.id} has more time: ${order.size} ${config.ticker} @ ${order.price} = $${order.funds} | expires ${moment.duration(timeLeft, 'milliseconds').humanize()}`);
+        remaining.push(order);
       }
     }
+    // https://help.coinbase.com/en/pro/other-topics/api/faq-on-api#:~:text=What%20are%20the%20rate%20limits%20for%20Coinbase%20Pro%20API%3F&text=For%20Public%20Endpoints%2C%20our%20rate,requests%20per%20second%20in%20bursts.&text=The%20FIX%20API%20rate%20limit%20is%2050%20messages%20per%20second.
+    // prevent api rate limiting (3 per second)
+    await sleep(1000);
   }
-  //memory.makerOrders.orders = memory.makerOrders.orders.filter(o => o.pair !== config.productID); // purge these from the active memory of orders to track (they either filled or were deleted)
-  // save makerOrders to disk in case this process crashes
-  fs.writeFileSync(config.maker_file, JSON.stringify(memory.makerOrders, null, 2));
+
+  // if we have set CPBB_REBUY_REBUILD threshold
+  if (remaining.length >= config.rebuy.rebuild) {
+    const remainingFunds = remaining.reduce((sum, order) => add(sum, order.funds), 0);
+    // the highest limit on the books
+    let basePrice = remaining.reduce((max, order) => {
+      if (Number(order.price) > max) max = Number(order.price);
+      return max
+    }, 0);
+    // since the highest limit is already at drop[0], we need to reverse that calculation
+    // so that the first limit will be at the highest limit and not another drop[0] below that
+    // (so it isn't always moving down further)
+    // increase the price by the first drop point %
+    basePrice = add(basePrice, multiply(basePrice, config.rebuy.drops[0]));
+    log.zap(`alpha feature: rebuilding ${remaining.length} limits with $${remainingFunds} starting at ${basePrice}`);
+    log.now(`${remaining.length} limit orders. Rebuilding...`);
+    remaining.forEach(order => cancelOrder(order));
+    await postRebuys(basePrice, remainingFunds);
+    // }
+  } else {
+    // save makerOrders to disk in case this process crashes
+    fs.writeFileSync(config.maker_file, JSON.stringify(memory.makerOrders, null, 2));
+  }
 }

--- a/lib/rebuys.check.js
+++ b/lib/rebuys.check.js
@@ -92,8 +92,7 @@ module.exports = async () => {
     // (so it isn't always moving down further)
     // increase the price by the first drop point %
     basePrice = add(basePrice, multiply(basePrice, config.rebuy.drops[0]));
-    log.zap(`alpha feature: rebuilding ${remaining.length} limits with $${remainingFunds} starting at ${basePrice}`);
-    log.now(`${remaining.length} limit orders. Rebuilding...`);
+    log.zap(`rebuilding ${remaining.length} limits with $${remainingFunds} starting at ${basePrice}`);
     remaining.forEach(order => cancelOrder(order));
     await postRebuys(basePrice, remainingFunds);
     // }

--- a/lib/rebuys.check.js
+++ b/lib/rebuys.check.js
@@ -83,7 +83,7 @@ module.exports = async () => {
   if (remaining.length >= config.rebuy.rebuild) {
     const remainingFunds = remaining.reduce((sum, order) => add(sum, order.funds), 0);
     // the highest limit on the books
-    let basePrice = remaining.reduce((max, order) => {
+    const maxLimit = remaining.reduce((max, order) => {
       if (Number(order.price) > max) max = Number(order.price);
       return max
     }, 0);
@@ -91,8 +91,8 @@ module.exports = async () => {
     // so that the first limit will be at the highest limit and not another drop[0] below that
     // (so it isn't always moving down further)
     // increase the price by the first drop point %
-    basePrice = add(basePrice, multiply(basePrice, config.rebuy.drops[0]));
-    log.zap(`rebuilding ${remaining.length} limits with $${remainingFunds} starting at ${basePrice}`);
+    const basePrice = add(maxLimit, multiply(maxLimit, config.rebuy.drops[0]) * -1);
+    log.zap(`rebuilding ${remaining.length} limits with $${remainingFunds} starting at $${maxLimit} (base price $${basePrice})`);
     remaining.forEach(order => cancelOrder(order));
     await postRebuys(basePrice, remainingFunds);
     // }

--- a/lib/rebuys.post.js
+++ b/lib/rebuys.post.js
@@ -19,12 +19,13 @@ const log = require("./log");
 const memory = require("./memory");
 const processOrder = require('./process.order');
 const sleep = require('./sleep');
-module.exports = async (basePrice, maxFundsOverrid) => {
+module.exports = async (basePrice, maxFundsOverride) => {
   // starting percentage down from basePrice to place limit orders
   const dropPoints = config.rebuy.drops;
   // only set orders until they reach this threshold total
-  const maxFunds = maxFundsOverrid || config.rebuy.max;
+  const maxFunds = maxFundsOverride || config.rebuy.max;
   const sizes = config.rebuy.sizes;
+  log.zap(`Creating limit orders to rebuy from $${basePrice} up to $${maxFunds} worth of ${config.ticker}`);
   let usedFunds = 0;
   let addedOrders = 0;
   for (let i = 0; i < sizes.length; i++) {

--- a/lib/rebuys.post.js
+++ b/lib/rebuys.post.js
@@ -12,19 +12,21 @@ CPBB_REBUY_SIZE: ".0001,.0001,.0002,.0002,.0003,.0003,.0004,.0004,.0005,.0005",
 // note: you have to define at least the number of points in CPBB_REBUY_SIZE
 CPBB_REBUY_AT: "-4,-6,-8,-10,-12,-15,-20,-25,-50,-80",
  */
-const { add, divide, multiply } = require('./math');
+const { add, multiply } = require('./math');
 const config = require('../config');
 const fs = require('fs');
 const log = require("./log");
 const memory = require("./memory");
 const processOrder = require('./process.order');
-module.exports = async (basePrice) => {
+const sleep = require('./sleep');
+module.exports = async (basePrice, maxFundsOverrid) => {
   // starting percentage down from basePrice to place limit orders
-  const dropPoints = process.env.CPBB_REBUY_AT.split(',').map(p => divide(p, 100));
+  const dropPoints = config.rebuy.drops;
   // only set orders until they reach this threshold total
-  const maxFunds = Number(process.env.CPBB_REBUY_MAX);
-  const sizes = process.env.CPBB_REBUY_SIZE.split(',').map(s => Number(s));
+  const maxFunds = maxFundsOverrid || config.rebuy.max;
+  const sizes = config.rebuy.sizes;
   let usedFunds = 0;
+  let addedOrders = 0;
   for (let i = 0; i < sizes.length; i++) {
     let percentageDrop = dropPoints[i];
     let size = sizes[i];
@@ -43,6 +45,7 @@ module.exports = async (basePrice) => {
     let orderResponse = await processOrder(order);
     log.debug({ order, orderResponse });
     log.now(`⬇️  posted limit order for ${size} ${config.ticker} @ ${price} = $${funds} (${percentageDrop * 100}% drop)`);
+    addedOrders++;
     memory.makerOrders.orders.push({
       created_at: orderResponse.created_at,
       pair: config.productID,
@@ -51,8 +54,10 @@ module.exports = async (basePrice) => {
       price,
       size
     });
+    await sleep(1000); // avoid rate limiting
   }
-  log.debug(`REBUY: set ${memory.makerOrders.orders.length} limit orders totalling $${usedFunds}`);
+  const limitTotal = memory.makerOrders.orders.reduce((sum, order) => add(sum, order.funds), 0);
+  log.debug(`REBUY: Added ${addedOrders} limit buys totaling $${usedFunds}. Now ${memory.makerOrders.orders.length} limit orders totaling $${limitTotal}`);
   // save makerOrders to disk in case this process crashes
   fs.writeFileSync(config.maker_file, JSON.stringify(memory.makerOrders, null, 2));
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coinbase_position_builder_bot",
-  "version": "2.4.2",
+  "version": "2.5.0",
   "description": "Position Building Bot for Accumulating Bitcoin (or other assets) via Coinbase Pro, while taking advantage of pumps",
   "main": "index.js",
   "scripts": {

--- a/run.mine.config.js
+++ b/run.mine.config.js
@@ -9,12 +9,12 @@ module.exports = {
       script,
       watch,
       env: {
-        // VERBOSE: true,
+        VERBOSE: false,
         NODE_ENV: "production",
         CPBB_APIPASS: apiKeys.CPBB_APIPASS,
         CPBB_APIKEY: apiKeys.CPBB_APIKEY,
         CPBB_APISEC: apiKeys.CPBB_APISEC,
-        CPBB_FREQ: "12 */6 * * *",
+        CPBB_FREQ: "5 */6 * * *",
         CPBB_TICKER: "BTC",
         CPBB_CURRENCY: "USD",
         CPBB_VOL: 100,
@@ -31,7 +31,15 @@ module.exports = {
         // default behavior is on the next action point (if they didn't fill)
         // if CPBB_REBUY_CANCEL is set, this is a number of minutes after the limit order
         // creation timestamp that it will be considered ready to cancel if not filled
-        CPBB_REBUY_CANCEL: 60 * 24 * 4
+        CPBB_REBUY_CANCEL: 60 * 24 * 4,
+        // if there are twelve unfilled limit orders remaining on the books, expire them
+        // and rebuild the limit order set immediately using the sum total of funds
+        // used for all the limit orders and starting with the price at the highest limit value
+        // using the rebuy config to create new orders
+        // NOTE: if you use this setting, it is recommended that you set it higher than
+        // the number of items in your CPBB_REBUY_AT config so it doesn't excessively rebuild
+        // the same oders over and over
+        CPBB_REBUY_REBUILD: 5 // short term testing
       },
     },
     {
@@ -44,7 +52,7 @@ module.exports = {
         CPBB_APIPASS: apiKeys.CPBB_APIPASS,
         CPBB_APIKEY: apiKeys.CPBB_APIKEY,
         CPBB_APISEC: apiKeys.CPBB_APISEC,
-        CPBB_FREQ: "02 15 * * *",
+        CPBB_FREQ: "13 7 * * *",
         CPBB_TICKER: "ETH",
         CPBB_CURRENCY: "USD",
         CPBB_VOL: 25,
@@ -56,7 +64,8 @@ module.exports = {
         CPBB_REBUY_SIZE: ".001,.002,.003,.004,.005,.006,.007,.008,.009,.01",
         // note: you have to define at least the number of points in CPBB_REBUY_SIZE
         CPBB_REBUY_AT: "-4,-6,-8,-10,-12,-15,-20,-25,-50,-80",
-        CPBB_REBUY_CANCEL: 60 * 24 * 2
+        CPBB_REBUY_CANCEL: 60 * 24 * 2,
+        CPBB_REBUY_REBUILD: 12
       },
     },
     {
@@ -68,7 +77,7 @@ module.exports = {
         CPBB_APIPASS: apiKeys.CPBB_APIPASS,
         CPBB_APIKEY: apiKeys.CPBB_APIKEY,
         CPBB_APISEC: apiKeys.CPBB_APISEC,
-        CPBB_FREQ: "02 16 * * *",
+        CPBB_FREQ: "5 8 * * *",
         CPBB_TICKER: "LTC",
         CPBB_CURRENCY: "USD",
         CPBB_VOL: 25,
@@ -80,7 +89,8 @@ module.exports = {
         CPBB_REBUY_SIZE: ".01,.02,.03,.04,.05,.06,.07,.08,.09,.1",
         // note: you have to define at least the number of points in CPBB_REBUY_SIZE
         CPBB_REBUY_AT: "-4,-6,-8,-10,-12,-15,-20,-25,-50,-80",
-        CPBB_REBUY_CANCEL: 60 * 24 * 2
+        CPBB_REBUY_CANCEL: 60 * 24 * 2,
+        CPBB_REBUY_REBUILD: 12
       },
     },
     {
@@ -92,7 +102,7 @@ module.exports = {
         CPBB_APIPASS: apiKeys.CPBB_APIPASS,
         CPBB_APIKEY: apiKeys.CPBB_APIKEY,
         CPBB_APISEC: apiKeys.CPBB_APISEC,
-        CPBB_FREQ: "02 17 * * *",
+        CPBB_FREQ: "11 9 * * *",
         CPBB_TICKER: "DASH",
         CPBB_CURRENCY: "USD",
         CPBB_VOL: 25,
@@ -105,7 +115,8 @@ module.exports = {
         // rebuy at these percentage drop targets
         // note: you have to define at least the number of points in CPBB_REBUY_SIZE
         CPBB_REBUY_AT: "-4,-6,-8,-10,-12,-15,-20,-25,-50,-80",
-        CPBB_REBUY_CANCEL: 60 * 24 * 2
+        CPBB_REBUY_CANCEL: 60 * 24 * 2,
+        CPBB_REBUY_REBUILD: 12
       },
     },
   ],

--- a/run.mine.config.js
+++ b/run.mine.config.js
@@ -52,7 +52,7 @@ module.exports = {
         CPBB_APIPASS: apiKeys.CPBB_APIPASS,
         CPBB_APIKEY: apiKeys.CPBB_APIKEY,
         CPBB_APISEC: apiKeys.CPBB_APISEC,
-        CPBB_FREQ: "13 7 * * *",
+        CPBB_FREQ: "5 7 * * *",
         CPBB_TICKER: "ETH",
         CPBB_CURRENCY: "USD",
         CPBB_VOL: 25,
@@ -65,7 +65,7 @@ module.exports = {
         // note: you have to define at least the number of points in CPBB_REBUY_SIZE
         CPBB_REBUY_AT: "-4,-6,-8,-10,-12,-15,-20,-25,-50,-80",
         CPBB_REBUY_CANCEL: 60 * 24 * 2,
-        CPBB_REBUY_REBUILD: 12
+        CPBB_REBUY_REBUILD: 6
       },
     },
     {

--- a/run.mine.config.js
+++ b/run.mine.config.js
@@ -39,7 +39,7 @@ module.exports = {
         // NOTE: if you use this setting, it is recommended that you set it higher than
         // the number of items in your CPBB_REBUY_AT config so it doesn't excessively rebuild
         // the same oders over and over
-        CPBB_REBUY_REBUILD: 5 // short term testing
+        CPBB_REBUY_REBUILD: 12
       },
     },
     {
@@ -65,7 +65,7 @@ module.exports = {
         // note: you have to define at least the number of points in CPBB_REBUY_SIZE
         CPBB_REBUY_AT: "-4,-6,-8,-10,-12,-15,-20,-25,-50,-80",
         CPBB_REBUY_CANCEL: 60 * 24 * 2,
-        CPBB_REBUY_REBUILD: 6
+        CPBB_REBUY_REBUILD: 12
       },
     },
     {

--- a/sample.btcusd.limit_only.config.js
+++ b/sample.btcusd.limit_only.config.js
@@ -48,7 +48,15 @@ module.exports = {
         // 5 minutes with a daily job timer will cancel the order after 1 day, not 5 minutes
         // set to 0 or remove ENV var to have default behavior of canceling on the next
         // action timer
-        CPBB_REBUY_CANCEL: 60 * 24 * 1
+        CPBB_REBUY_CANCEL: 60 * 24 * 2,
+        // if there are twelve unfilled limit orders remaining on the books, expire them
+        // and rebuild the limit order set immediately using the sum total of funds
+        // used for all the limit orders that existed, starting with the price at the highest limit value
+        // using the rebuy config to create new orders
+        // NOTE: if you use this setting, it is recommended that you set it higher than
+        // the number of items in your CPBB_REBUY_AT config so it doesn't excessively rebuild
+        // the same oders over and over
+        CPBB_REBUY_REBUILD: 12
       },
     },
   ],

--- a/sample.btcusd.rebuy.config.js
+++ b/sample.btcusd.rebuy.config.js
@@ -42,7 +42,15 @@ module.exports = {
         // 5 minutes with a daily job timer will cancel the order after 1 day, not 5 minutes
         // set to 0 or remove ENV var to have default behavior of canceling on the next
         // action timer
-        CPBB_REBUY_CANCEL: 60 * 24 * 1
+        CPBB_REBUY_CANCEL: 60 * 24 * 5,
+        // if there are twelve unfilled limit orders remaining on the books, expire them
+        // and rebuild the limit order set immediately using the sum total of funds
+        // used for all the limit orders that existed, starting with the price at the highest limit value
+        // using the rebuy config to create new orders
+        // NOTE: if you use this setting, it is recommended that you set it higher than
+        // the number of items in your CPBB_REBUY_AT config so it doesn't excessively rebuild
+        // the same oders over and over
+        CPBB_REBUY_REBUILD: 12
       },
     },
   ],

--- a/sample.experimental.ltcbtc.config.js
+++ b/sample.experimental.ltcbtc.config.js
@@ -21,8 +21,6 @@ module.exports = {
       watch: ["*.js", "coinbase", "lib"],
       env: {
         NODE_ENV: "production",
-        // sell ALL when profitable!
-        CPBB_LIQUIDATE: true,
         CPBB_APIPASS: apiKeys.CPBB_APIPASS,
         CPBB_APIKEY: apiKeys.CPBB_APIKEY,
         CPBB_APISEC: apiKeys.CPBB_APISEC,

--- a/tools/create.history.js
+++ b/tools/create.history.js
@@ -1,0 +1,87 @@
+/**
+ * go through entire fills history and generate a history file
+ * invoke like so:
+ *
+ * CPBB_TICKER=ETH CPBB_CURRENCY=USD CPBB_APY=150 CPBB_SINCE=2015-01-01 node create.history.js
+ *
+ * or to use a cached fills file:
+ * CPBB_TICKER=ETH CPBB_CURRENCY=USD CPBB_APY=150 CPBB_SINCE=2015-01-01 CPBB_FILLS=../data/fills_ETH-USD.json node create.history.js
+ *
+ */
+const { exec } = require('child_process');
+const config = require('../config');
+const fs = require('fs');
+const log = require('../lib/log');
+const getFills = require('../coinbase/get.fills');
+const history = require('../lib/history');
+const map = require("lodash.map");
+const {multiply} = require('../lib/math');
+
+console.log('load fills', process.env.CPBB_FILLS);
+const fillsFromFile = process.env.CPBB_FILLS ? require(process.env.CPBB_FILLS) : [];
+console.log(fillsFromFile[0])
+
+const backup = config.history_file.replace('.tsv', `_backup_${new Date().getTime()}.tsv`);
+fs.copyFileSync(config.history_file, backup);
+log.ok(`backed up history file in ${backup}`);
+
+(async () => {
+
+  const fills = fillsFromFile.length ?  fillsFromFile.filter(f=>new Date(f.create_at) > process.env.CPBB_SINCE||'2015-01-01') : await getFills({since: process.env.CPBB_SINCE||'2010-01-01'});
+  // so we can rerun this without calling the API again
+  if(!fillsFromFile.length) fs.writeFileSync(`${__dirname}/../data/fills_${config.productID}.json`, JSON.stringify(fills, null, 2));
+
+  // reverse it to oldest->newest
+  fills.reverse();
+
+  log.ok('first fill record: ', fills[0]);
+  const all = fills.map(f=>{
+    // if(!f.usd_volume){
+    //   console.log('no volume?', f);
+    // }
+    const funds = multiply(f.price, f.size);
+    return {
+      Time: f.created_at,
+      Price: f.price,
+      Holding: 0,
+      Value: 0,
+      Funds: f.side==='sell' ? multiply(funds, -1) : funds,
+      Shares: f.side==='sell' ? multiply(f.size, -1) : f.size,
+      PeriodRate: 0,
+      ExpectedGain: 0,
+      TotalInput: 0,
+      Target: 0,
+      Diff: 0,
+      EndValue: 0,
+      Realized: 0,
+      TotalValue: 0,
+      Liquid: 0,
+      Profit: 0,
+      ID: f.order_id
+    }
+  });
+
+  // write new history file
+  const headers = history.headerRow.includes('\tID') ? history.headerRow : history.headerRow + '\tID';
+  const data = [
+    `${headers}`,
+    ...all.map(row => map(row, v => v).join("\t")),
+  ].join("\n");
+
+  // console.log(data)
+  const file = `${__dirname}/../data/history.${config.productID}.tsv`;
+  fs.writeFileSync(file, data);
+  log.ok(`updated history ${file} from api data`);
+
+  exec('node ./adjust.apy.js', process.env, (error, stdout, stderr) => {
+    if (error) {
+      log.error(`exec error: ${error}`);
+      return;
+    }
+    console.log(stdout);
+    console.error(stderr);
+  });
+
+  log.ok('all done');
+
+})();


### PR DESCRIPTION
# 2.5.0
- New configuration of `CPBB_REBUY_REBUILD`, which is a number of active limit orders on the books to consider the set ready for a rebuild based on the existing rebuy SIZE/AT config.
- NOTE: this is only useful if you have `CPBB_REBUY_CANCEL` set to something other than 0, where limit orders can pile up over many runs. By default, limit orders are canceled on the next cron.
- If `CPBB_REBUY_REBUILD` is triggered, existing limit orders will be canceled and new orders will be built from the highest price of the order set, and using the total `funds` from the limit orders on the books. For example, if you normally put $50 into rebuy orders, but the rebuy limits have piled up through several sell operations, you might have 20 limit orders worth $120 on the books, all accumulated in one region. Setting `CPBB_REBUY_REBUILD` to 20 (or less) will cause the next run to cancel these limit orders and build a new set of limit orders up to $120, up to the number of drop points configured in `CPBB_REBUY_AT`
- `CPBB_REBUY_REBUILD` should be a bigger number than the number of drop points configured in `CPBB_REBUY_AT` or each cron can end up canceling and recreating the same order set.
- Resuming checking each limit order to be sure they haven't been manually deleted  
- Removing 404 limit orders from tracking (limit orders can be manually deleted or deleted by Coinbase system maintenance)
- Correcting rate limiting issues by sleeping between rebuy checks and posts