### PR TITLE
prevent parsing APY and ID into Number (NaN)

### DIFF
--- a/lib/load.lastLog.js
+++ b/lib/load.lastLog.js
@@ -11,7 +11,7 @@ module.exports = () => {
   const lastLog = headers.reduce((obj, nextKey, index) => {
     obj[nextKey] = noHistory
       ? 0
-      : ['Time', 'Profit'].includes(nextKey)
+      : ['Time', 'Profit', 'APY', 'ID'].includes(nextKey)
       ? data[index]
       : Number(data[index]);
     return obj;


### PR DESCRIPTION
missing APY and ID as non-numeric fields