### PR TITLE
Use Remaining Available Funds in Rebuy on Last Order

### DIFF
--- a/coinbase/cb.request.js
+++ b/coinbase/cb.request.js
@@ -37,8 +37,13 @@ module.exports = async opts => {
     requestConfig.headers['Content-Type'] = 'application/json';
   }
   // log.debug({ requestConfig });
-  return request(requestConfig).catch(e => {
-    if (process.env.VERBOSE)
-      log.error(opts.method, opts.requestPath, `status error`, e);
+  return request(requestConfig).catch(({ reason, json }) => {
+    log.error(
+      opts.method,
+      opts.requestPath,
+      `status error`,
+      reason,
+      json || ''
+    );
   });
 };

--- a/coinbase/http.request.js
+++ b/coinbase/http.request.js
@@ -15,7 +15,7 @@ module.exports = params => {
           json = JSON.parse(responseBody);
         } catch (e) {
           log.error('failed to parse response from API', e);
-          reject(e);
+          reject({ reason: e.message });
         }
         if (res.statusCode === 429) {
           log.error(
@@ -30,7 +30,7 @@ module.exports = params => {
             process.exit();
           }
           log.debug(`${res.statusCode} error:`, responseBody);
-          return reject(res.statusCode);
+          return reject({ reason: res.statusCode, json });
         }
         resolve({ json, headers: res.headers });
         // resolve(json);
@@ -40,7 +40,7 @@ module.exports = params => {
     req.on('error', function (err) {
       // This is not a "Second reject", just a different sort of failure
       log.error(`error in API request/response`, err);
-      reject(err);
+      reject({ reason: err });
     });
     if (params.body) {
       // log.info(`write body`, params.body);

--- a/lib/rebuys.post.js
+++ b/lib/rebuys.post.js
@@ -12,7 +12,7 @@ CPBB_REBUY_SIZE: ".0001,.0001,.0002,.0002,.0003,.0003,.0004,.0004,.0005,.0005",
 // note: you have to define at least the number of points in CPBB_REBUY_SIZE
 CPBB_REBUY_AT: "-4,-6,-8,-10,-12,-15,-20,-25,-50,-80",
  */
-const { add, multiply } = require('./math');
+const { add, divide, multiply, subtract } = require('./math');
 const config = require('../config');
 const fs = require('fs');
 const log = require('./log');
@@ -31,12 +31,19 @@ module.exports = async (basePrice, maxFundsOverride) => {
   let usedFunds = 0;
   let addedOrders = 0;
   for (let i = 0; i < sizes.length; i++) {
+    if (usedFunds >= maxFunds) {
+      break; // done
+    }
     let percentageDrop = dropPoints[i];
     let size = sizes[i];
     let price = add(basePrice, multiply(basePrice, percentageDrop)).toFixed(2);
     let funds = multiply(size, price).toFixed(4);
     if (add(usedFunds, funds) > maxFunds) {
-      break; // stop processing
+      // this attmept would exceed the allowed limit
+      // use whatever is left of the funds on this last drop point
+      funds = subtract(maxFunds, usedFunds);
+      // size now depends on the funds used
+      size = divide(funds, price);
     }
     usedFunds = add(usedFunds, funds);
     let order = {
@@ -47,6 +54,14 @@ module.exports = async (basePrice, maxFundsOverride) => {
     };
     let orderResponse = await processOrder(order);
     log.debug({ order, orderResponse });
+    if (!orderResponse) {
+      log.error(
+        `Failed to place limit order for ${size}${
+          config.ticker
+        } @ ${price} = $${funds} (${percentageDrop * 100}% drop)`
+      );
+      return;
+    }
     log.now(
       `⬇️  posted limit order for ${size} ${
         config.ticker
@@ -61,6 +76,9 @@ module.exports = async (basePrice, maxFundsOverride) => {
       price,
       size,
     });
+    if (usedFunds >= maxFunds) {
+      break; // stop processing
+    }
     await sleep(1000); // avoid rate limiting
   }
   const limitTotal = memory.makerOrders.orders.reduce(

--- a/lib/rebuys.post.js
+++ b/lib/rebuys.post.js
@@ -60,7 +60,7 @@ module.exports = async (basePrice, maxFundsOverride) => {
           config.ticker
         } @ ${price} = $${funds} (${percentageDrop * 100}% drop)`
       );
-      return;
+      continue;
     }
     log.now(
       `⬇️  posted limit order for ${size} ${

--- a/lib/rebuys.post.js
+++ b/lib/rebuys.post.js
@@ -60,7 +60,7 @@ module.exports = async (basePrice, maxFundsOverride) => {
           config.ticker
         } @ ${price} = $${funds} (${percentageDrop * 100}% drop)`
       );
-      continue;
+      break;
     }
     log.now(
       `⬇️  posted limit order for ${size} ${

--- a/lib/rebuys.post.js
+++ b/lib/rebuys.post.js
@@ -43,7 +43,7 @@ module.exports = async (basePrice, maxFundsOverride) => {
       // use whatever is left of the funds on this last drop point
       funds = subtract(maxFunds, usedFunds);
       // size now depends on the funds used
-      size = divide(funds, price);
+      size = divide(funds, price).toFixed(8);
     }
     usedFunds = add(usedFunds, funds);
     let order = {
@@ -56,7 +56,7 @@ module.exports = async (basePrice, maxFundsOverride) => {
     log.debug({ order, orderResponse });
     if (!orderResponse) {
       log.error(
-        `Failed to place limit order for ${size}${
+        `Failed to place limit order for ${size} ${
           config.ticker
         } @ ${price} = $${funds} (${percentageDrop * 100}% drop)`
       );

--- a/package-lock.json
+++ b/package-lock.json
@@ -905,6 +905,7 @@
         "jest-resolve": "^26.6.2",
         "jest-util": "^26.6.2",
         "jest-worker": "^26.6.2",
+        "node-notifier": "^8.0.0",
         "slash": "^3.0.0",
         "source-map": "^0.6.0",
         "string-length": "^4.0.1",
@@ -2646,7 +2647,8 @@
         "esprima": "^4.0.1",
         "estraverse": "^4.2.0",
         "esutils": "^2.0.2",
-        "optionator": "^0.8.1"
+        "optionator": "^0.8.1",
+        "source-map": "~0.6.1"
       },
       "bin": {
         "escodegen": "bin/escodegen.js",
@@ -4990,6 +4992,7 @@
         "@types/node": "*",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
+        "fsevents": "^2.1.2",
         "graceful-fs": "^4.2.4",
         "jest-regex-util": "^26.0.0",
         "jest-serializer": "^26.6.2",


### PR DESCRIPTION
Per conversation with Brendan in Slack.

- Also added a return and log if the order fails at the API--in case it gets rejected due to the size being too small (or any other api rejection reason)
- Might be good to calculate the orders first and then set the last remainder on the one prior if it couldn't make a valid sized order, but we'd have to know the minimum size for the ticker being used. 