### PR TITLE
2.7.2

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,11 @@
+# 2.7.2
+
+- use product info to calculate precision for limit order size
+- reduce log and add note about Insufficient Funds
+- validate rebuy size and drop points before startup
+- use multiply and divide everywhere
+- correct rounding error on printing drop target with limit order status (just in log)
+
 # 2.7.0
 
 - More tests!

--- a/config.js
+++ b/config.js
@@ -17,7 +17,7 @@ const config = {
   apy: divide(process.env.CPBB_APY || 15, 100),
   rebuy: {
     // ms after limit order placed before it is able to be canceled due to not filling
-    cancel: Number(process.env.CPBB_REBUY_CANCEL || 0) * 60000,
+    cancel: multiply(process.env.CPBB_REBUY_CANCEL || 0, 60000),
     drops: process.env.CPBB_REBUY
       ? process.env.CPBB_REBUY.split(',')
           .map(p => {

--- a/config.js
+++ b/config.js
@@ -62,6 +62,19 @@ const config = {
   },
   pjson,
 };
+
+if (config.rebuy.drops.length !== config.rebuy.sizes.length) {
+  log.error(
+    `Rebuy is misconfigured. You have ${config.rebuy.drops.length} drop points and ${config.rebuy.sizes.length} order sizes. Perhaps the new single CPBB_REBUY config will make it easier.`
+  );
+  if (process.env.CPBB_REBUY_AT) {
+    log.error(
+      `Consider switching CPBB_REBUY_AT and CPBB_REBUY_SIZE to the new single CPBB_REBUY config.`
+    );
+  }
+  process.exit(1);
+}
+
 config.productID = `${config.ticker}-${config.currency}`;
 let historyName = config.productID;
 // currenly, we only support reversing BTC orders to support ticker pairs that don't exist
@@ -98,4 +111,5 @@ if (!fs.existsSync(config.maker_file)) {
     config.maker_file
   );
 }
+
 module.exports = config;

--- a/index.js
+++ b/index.js
@@ -14,13 +14,19 @@ const job = new CronJob(config.freq, action);
 
 const startEngine = async () => {
   const product = await getProduct(config.productID);
+  product.precision = product.base_increment
+    .replace('0.', '')
+    .replace(/1[0]+/, '1').length;
   memory.product = product;
+  // log.now({product})
   log.now(
     `${product.status === 'online' ? '🆗' : '🚨'} ${config.productID} ${
       product.status
-    }, min size ${product.base_min_size}, min funds ${
-      product.min_market_funds
-    } ${product.status_message}`
+    }, min size ${product.base_min_size}, precision: ${
+      product.base_increment
+    } (${product.precision}), min funds ${product.min_market_funds} ${
+      product.status_message
+    }`
   );
   if (
     !apiKeys.CPBB_APIKEY ||

--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ const startEngine = async () => {
       config.dry ? 'DRY RUN' : 'LIVE'
     } mode, ${config.vol} $${config.currency} ➡️  $${config.ticker} @ cron(${
       config.freq
-    }), ${config.apy * 100}% APY${
+    }), ${multiply(config.apy, 100)}% APY${
       process.env.VERBOSE === 'true' ? `, verbose logging` : ''
     }`
   );

--- a/lib/action.js
+++ b/lib/action.js
@@ -42,12 +42,8 @@ module.exports = async opts => {
   log.debug('order', order);
 
   if (!order) {
-    log.error(`Order failed. Please file a bug report.`);
-  }
-
-  if (!order) {
     log.error(
-      'something is wrong with the API. Please file a bug report on https://github.com/jasonedison/coinbase_position_builder_bot/issues so we can investigate and add fault tolerance for this case.'
+      'Order failed. If this is not because of an Insufficient Funds error, please file a bug report on https://github.com/jasonedison/coinbase_position_builder_bot/issues so we can investigate and add fault tolerance for this case.'
     );
     return;
   }

--- a/lib/rebuys.post.js
+++ b/lib/rebuys.post.js
@@ -43,7 +43,7 @@ module.exports = async (basePrice, maxFundsOverride) => {
       // use whatever is left of the funds on this last drop point
       funds = subtract(maxFunds, usedFunds);
       // size now depends on the funds used
-      size = divide(funds, price).toFixed(8);
+      size = divide(funds, price).toFixed(memory.product.precision);
       // if this order would be too small, add the funds to the last order
       if (Number(size) < Number(memory.product.base_min_size)) {
         if (!lastOrder) {
@@ -54,7 +54,9 @@ module.exports = async (basePrice, maxFundsOverride) => {
           break;
         }
         lastOrder.funds = add(lastOrder.funds, funds);
-        lastOrder.size = add(lastOrder.size, size);
+        lastOrder.size = add(lastOrder.size, size).toFixed(
+          memory.product.precision
+        );
         usedFunds = add(usedFunds, funds);
         break;
       }

--- a/lib/rebuys.post.js
+++ b/lib/rebuys.post.js
@@ -76,19 +76,14 @@ module.exports = async (basePrice, maxFundsOverride) => {
     let orderResponse = await processOrder(order);
     log.debug({ order, orderResponse });
     await sleep(config.sleep.rebuyPost); // avoid rate limiting
+    const detailLog = `limit order for ${order.size} ${config.ticker} @ ${
+      order.price
+    } = $${order.funds} (${multiply(order.percentageDrop, 100)}% drop)`;
     if (!orderResponse) {
-      log.error(
-        `Failed to place limit order for ${order.size} ${config.ticker} @ ${
-          order.price
-        } = $${order.funds} (${order.percentageDrop * 100}% drop)`
-      );
+      log.error(`Failed to place ${detailLog}`);
       continue;
     }
-    log.now(
-      `⬇️  posted limit order for ${order.size} ${config.ticker} @ ${
-        order.price
-      } = $${order.funds} (${order.percentageDrop * 100}% drop)`
-    );
+    log.now(`⬇️  posted ${detailLog}`);
     addedOrders++;
     memory.makerOrders.orders.push({
       created_at: orderResponse.created_at,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coinbase_position_builder_bot",
-  "version": "2.7.1",
+  "version": "2.7.2",
   "description": "Position Building Bot for Accumulating Bitcoin (or other assets) via Coinbase Pro, while taking advantage of pumps",
   "jest": {
     "collectCoverageFrom": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coinbase_position_builder_bot",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "description": "Position Building Bot for Accumulating Bitcoin (or other assets) via Coinbase Pro, while taking advantage of pumps",
   "jest": {
     "collectCoverageFrom": [

--- a/run.mine.config.js
+++ b/run.mine.config.js
@@ -20,7 +20,7 @@ module.exports = {
         CPBB_VOL: 100,
         CPBB_APY: 150,
         // max $ spend on limit rebuys
-        CPBB_REBUY_MAX: 50,
+        CPBB_REBUY_MAX: 75,
         // minimum order is .0001 BTC ($5 at $50K)
         // rebuy logic will place up orders at this size until CPBB_REBUY_MAX is reached
         // CPBB_REBUY_SIZE:
@@ -30,7 +30,7 @@ module.exports = {
         // CPBB_REBUY_AT:
         //   '-4,-6,-8,-10,-12,-15,-20,-25,-30,-35,-40,-50,-60,-70,-80,-90',
         CPBB_REBUY:
-          '.0001@4,.0002@6,.0004@8,.0008@10,.001@12,.002@15,.004@20,.008@25,.016@30,.032@35,.064@40,.128@50,.256@60,.512@70,1.024@80,2.048@90',
+          '.0001@2,.0002@3,.0003@4,.0004@5,.0005@6,.0006@7,.0007@8,.0008@10,.001@12,.002@15,.004@20,.008@25,.016@30,.032@35,.064@40,.128@50,.256@60,.512@70,1.024@80,2.048@90',
         // when should we cancel limit orders?
         // default behavior is on the next action point (if they didn't fill)
         // if CPBB_REBUY_CANCEL is set, this is a number of minutes after the limit order
@@ -59,14 +59,14 @@ module.exports = {
         CPBB_FREQ: '15 */4 * * *',
         CPBB_TICKER: 'ETH',
         CPBB_CURRENCY: 'USD',
-        CPBB_VOL: 5,
+        CPBB_VOL: 10,
         CPBB_APY: 100,
         // max $ spend on limit rebuys
-        CPBB_REBUY_MAX: 5,
+        CPBB_REBUY_MAX: 10,
         // minimum order is .001 ETH ($5 at $5K)
         // rebuy logic will place orders at this size until CPBB_REBUY_MAX is reached
         CPBB_REBUY:
-          '.001@4,.002@6,.003@8,.004@10,.005@12,.01@15,.02@20,.04@25,.08@30,.16@35,.32@40,.64@50,1.28@60,2.56@70,5.12@80,10.24@90',
+          '.001@2,.002@4,.003@6,.004@8,.005@10,.01@15,.02@20,.04@25,.08@30,.16@35,.32@40,.64@50,1.28@60,2.56@70,5.12@80,10.24@90',
         CPBB_REBUY_CANCEL: 60 * 24 * 14,
         CPBB_REBUY_REBUILD: 17,
       },
@@ -80,17 +80,17 @@ module.exports = {
         CPBB_APIPASS: apiKeys.CPBB_APIPASS,
         CPBB_APIKEY: apiKeys.CPBB_APIKEY,
         CPBB_APISEC: apiKeys.CPBB_APISEC,
-        CPBB_FREQ: '25 8 * * *',
+        CPBB_FREQ: '25 */4 * * *',
         CPBB_TICKER: 'LTC',
         CPBB_CURRENCY: 'USD',
-        CPBB_VOL: 25,
+        CPBB_VOL: 10,
         CPBB_APY: 100,
         // max $ spend on limit rebuys
-        CPBB_REBUY_MAX: 15,
+        CPBB_REBUY_MAX: 10,
         // minimum order is in LTC (.01, which is $5 at $500)
         // rebuy logic will place orders at this size until CPBB_REBUY_MAX is reached
         CPBB_REBUY:
-          '.01@4,.02@6,.03@8,.04@10,.05@12,.1@15,.2@20,.4@25,.8@30,1.6@35,3.2@40,6.4@50,12.8@60,25.6@70,51.2@80,102.4@90',
+          '.01@2,.02@4,.03@6,.04@8,.05@10,.1@15,.2@20,.4@25,.8@30,1.6@35,3.2@40,6.4@50,12.8@60,25.6@70,51.2@80,102.4@90',
         CPBB_REBUY_CANCEL: 60 * 24 * 14,
         CPBB_REBUY_REBUILD: 17,
       },
@@ -117,7 +117,7 @@ module.exports = {
           '.01,.02,.03,.04,.05,.1,.2,.4,.8,1.6,3.2,6.4,12.8,25.6,51.2,102.4',
         // note: you have to define at least the number of points in CPBB_REBUY_SIZE
         CPBB_REBUY_AT:
-          '-4,-6,-8,-10,-12,-15,-20,-25,-30,-35,-40,-50,-60,-70,-80,-90',
+          '-2,-4,-6,-8,-10,-15,-20,-25,-30,-35,-40,-50,-60,-70,-80,-90',
         CPBB_REBUY_CANCEL: 60 * 24 * 14,
         CPBB_REBUY_REBUILD: 17,
       },

--- a/run.mine.config.js
+++ b/run.mine.config.js
@@ -122,5 +122,28 @@ module.exports = {
         CPBB_REBUY_REBUILD: 17,
       },
     },
+    {
+      name: 'xtz',
+      script,
+      watch: watch,
+      env: {
+        NODE_ENV: 'production',
+        CPBB_APIPASS: apiKeys.CPBB_APIPASS,
+        CPBB_APIKEY: apiKeys.CPBB_APIKEY,
+        CPBB_APISEC: apiKeys.CPBB_APISEC,
+        CPBB_FREQ: '45 */4 * * *',
+        CPBB_TICKER: 'XTZ',
+        CPBB_CURRENCY: 'USD',
+        CPBB_VOL: 10,
+        CPBB_APY: 100,
+        // max $ spend on limit rebuys
+        CPBB_REBUY_MAX: 5,
+        // minimum order is 1 XTZ, with a max precision of .01 XTZ
+        CPBB_REBUY:
+          '1@2,2@4,3@6,4@8,5@10,6@12,7@14,8@16,9@18,10@20,11@22,12@24,13@26,14@28,15@30,16@32,17@34,18@36,19@38,20@40,25@50,50@60,100@80',
+        CPBB_REBUY_CANCEL: 60 * 24 * 14,
+        CPBB_REBUY_REBUILD: 17,
+      },
+    },
   ],
 };

--- a/test/data/output.00.boot.log
+++ b/test/data/output.00.boot.log
@@ -1,6 +1,6 @@
 ⚡ creating log file from template ./data/history.TEST-USD.sandbox.tsv
 ⚡ creating maker file from template ./data/maker.orders.TEST-USD.sandbox.json
-🆗 TEST-USD online, min size 0.00100000, min funds 5
+🆗 TEST-USD online, min size 0.00100000, precision: 0.00000001 (8), min funds 5
 🤖 Position Builder Bot [VERSION], https://api-public.sandbox.pro.coinbase.com in LIVE mode, 100 $USD ➡️  $TEST @ cron(1 1 1 1 1), 25% APY
 💵 REBUY $50 of TEST: 0.0001@-2%, 0.0002@-4%, 0.0003@-6%, 0.0004@-8%, 0.0005@-10%
 🏦 $USD account loaded with 9900.2266348066930000 (99 buy actions)

--- a/test/nock/post.orders.js
+++ b/test/nock/post.orders.js
@@ -1,4 +1,5 @@
 const config = require('../../config');
+const memory = require('../../lib/memory');
 const nock = require('nock');
 const testConfig = require('../test.config');
 const getID = require('../lib/get.id');
@@ -26,10 +27,10 @@ module.exports = nock(config.api)
     if (!order.price) {
       order.price = testMemory.price;
     }
-    order.size = isLimit ? order.size : divide(executed, order.price);
+    order.size = isLimit ? Number(order.size) : divide(executed, order.price);
     const response = {
       id,
-      size: order.size.toFixed(8),
+      size: order.size.toFixed(memory.product.precision),
       product_id: config.productID,
       side: order.side,
       funds: isLimit ? undefined : funds.toFixed(16),
@@ -40,7 +41,7 @@ module.exports = nock(config.api)
       created_at: new Date().toISOString(),
       done_at: new Date().toISOString(),
       fill_fees: fees.toFixed(16),
-      filled_size: order.size.toFixed(8),
+      filled_size: order.size.toFixed(memory.product.precision),
       executed_value: executed.toFixed(16),
       status: isLimit ? 'posted' : 'done',
       settled: !isLimit,

--- a/tools/adjust.apy.js
+++ b/tools/adjust.apy.js
@@ -51,7 +51,7 @@ for (let i = 1; i < all.length; i++) {
   all[i].EndValue = add(all[i].Value, all[i].Funds);
   all[i].Realized = add(
     last.Realized,
-    all[i].Funds > 0 ? 0 : all[i].Funds * -1
+    all[i].Funds > 0 ? 0 : multiply(all[i].Funds, -1)
   );
   // total input does not subtract when we take profit (that's realized profit)
   all[i].TotalInput = add(last.TotalInput, all[i].Funds > 0 ? all[i].Funds : 0);

--- a/tools/project.changes.js
+++ b/tools/project.changes.js
@@ -42,8 +42,8 @@ log.debug(memory.lastLog);
     const changeParts = change.split(':');
     let usingPercent = changeParts[0].includes('%');
     const percentage = usingPercent
-      ? Number(changeParts[0].replace('%', '')) / 100
-      : Number(changeParts[0]) / memory.lastLog.Price - 1;
+      ? divide(changeParts[0].replace('%', ''), 100)
+      : divide(changeParts[0], memory.lastLog.Price) - 1;
     const periods = Number(changeParts[1]);
     const targetPrice = usingPercent
       ? add(memory.lastLog.Price, multiply(memory.lastLog.Price, percentage))
@@ -51,7 +51,7 @@ log.debug(memory.lastLog);
     // const starting = memory.lastLog.Price;
     if (usingPercent) {
       log.zap(
-        `targeting ${percentage * 100}% change from $${
+        `targeting ${multiply(percentage, 100)}% change from $${
           memory.lastLog.Price
         } in ${periods} periods, which ends at $${targetPrice}`
       );
@@ -65,10 +65,10 @@ log.debug(memory.lastLog);
     for (let i = 0; i < periods; i++) {
       let price = memory.lastLog.Price;
       let remainingPeriods = periods - i;
-      let percentRemaining = remainingPeriods / periods;
+      let percentRemaining = divide(remainingPeriods, periods);
       let changeRemaining = targetPrice - price;
       // if we had even change to our target
-      let changePerPeriod = changeRemaining / remainingPeriods;
+      let changePerPeriod = divide(changeRemaining, remainingPeriods);
 
       let change = changePerPeriod; // linear change
 
@@ -76,7 +76,7 @@ log.debug(memory.lastLog);
       // let change = multiply(changePerPeriod, changeMultiplier);
       change = multiply(
         change,
-        Math.random() < 0.5 * percentRemaining ? -1 : 1
+        Math.random() < multiply(0.5, percentRemaining) ? -1 : 1
       );
 
       price = add(price, change);

--- a/tools/project.experiment.js
+++ b/tools/project.experiment.js
@@ -48,7 +48,7 @@ let periodCounter = 0;
     let remainingPeriods = periods - i;
     let price = memory.lastLog.Price;
     let change = multiply(price, Math.random(), targetVolatility);
-    let percentRemaining = remainingPeriods / periods;
+    let percentRemaining = divide(remainingPeriods, periods);
     targetFloor = add(targetFloor, multiply(targetFloor, 0.001));
     targetCeiling = add(targetCeiling, multiply(targetCeiling, 0.001));
 
@@ -74,7 +74,7 @@ let periodCounter = 0;
         // are we really going to do it?
         change = multiply(
           change,
-          Math.random() < targetDownChance * percentRemaining ? -1 : 1
+          Math.random() < multiply(targetDownChance, percentRemaining) ? -1 : 1
         );
       }
       price = add(price, change);
@@ -99,8 +99,9 @@ let periodCounter = 0;
   log.now(
     `projected ${ticker} between $${targetFloor} - $${targetCeiling} until ${targetDate} with $${
       config.vol
-    } every ${targetMinutes} minutes, targeting ${
-      config.apy * 100
-    }% APY, and a ${targetDownChance} chance of going down rather than up (diminishing over time)`
+    } every ${targetMinutes} minutes, targeting ${multiply(
+      config.apy,
+      100
+    )}% APY, and a ${targetDownChance} chance of going down rather than up (diminishing over time)`
   );
 })();

--- a/tools/upgrade_2.2.0.js
+++ b/tools/upgrade_2.2.0.js
@@ -21,7 +21,7 @@ const uniqFilter = (value, index, self) => {
 };
 
 // const fills = require(`../data/fills_${config.productID}.json`);
-const { add, subtract } = require('../lib/math');
+const { add, subtract, multiply } = require('../lib/math');
 const backup = config.history_file.replace(
   '.tsv',
   `_backup_${new Date().getTime()}.tsv`
@@ -91,8 +91,8 @@ const backup = config.history_file.replace(
     });
 
     if (sold) {
-      shares = shares * -1;
-      usd = subtract(usd, fee) * -1;
+      shares = multiply(shares, -1);
+      usd = multiply(subtract(usd, fee), -1);
     } else {
       usd = add(usd, fee);
     }


### PR DESCRIPTION
- use product info to calculate precision for limit order size
- reduce log and add note about Insufficient Funds
- validate rebuy size and drop points before startup
- use multiply and divide everywhere
- correct rounding error on printing drop target with limit order status (just in log)