### PR TITLE
4.1.0 - random delay to avoid bot detection

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+# 4.0.1
+
+- corrected total paid calculation on startup log (UI only change)
+
 # 4.0.0
 
 - breaking change in configs: removing support for old `CPBB_REBUY_AT` and `CPBB_REBUY_SIZE` split env configs. Use new `CPBB_REBUY` (single config)

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,7 @@
 # 4.1.0
 
 - `CPBB_RANDOM_DELAY` environmental config option can be set to a maximum number of minutes to randomly delay the cron event. For example, setting `CPBB_RANDOM_DELAY: 5` will make each cron action wait a random number of milliseconds between 0 and 5 minutes from the triggered cron event time before running the action. This helps to avoid being detected and manipulated by bots as an agent that always does a buy action of a certain dollar amount every day at 10am UTC. This regularity is something manipulators can notice in the stream of event data coming from the trading API and use to time high volume trading manipulation, knowing that you will eat into their limit orders at whatever point they can manipulate the order books into being at the time your regular cron action triggers. In short, it is `recommended` to set this value to something though the default value is 0 to keep the [principle of least astonishment](https://en.wikipedia.org/wiki/Principle_of_least_astonishment). Note that you should provide enough buffer between multiple engines so they don't occasonally run queries at the same time, as that could trigger rate limiting and cause one of your processes to fail to trade.
+- Fix issue with `tools/create.history.js` that caused the first row of data to not be counted in the totals
 
 # 4.0.1
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+# 4.1.0
+
+- `CPBB_RANDOM_DELAY` environmental config option can be set to a maximum number of minutes to randomly delay the cron event. For example, setting `CPBB_RANDOM_DELAY: 5` will make each cron action wait a random number of milliseconds between 0 and 5 minutes from the triggered cron event time before running the action. This helps to avoid being detected and manipulated by bots as an agent that always does a buy action of a certain dollar amount every day at 10am UTC. This regularity is something manipulators can notice in the stream of event data coming from the trading API and use to time high volume trading manipulation, knowing that you will eat into their limit orders at whatever point they can manipulate the order books into being at the time your regular cron action triggers. In short, it is `recommended` to set this value to something though the default value is 0 to keep the [principle of least astonishment](https://en.wikipedia.org/wiki/Principle_of_least_astonishment). Note that you should provide enough buffer between multiple engines so they don't occasonally run queries at the same time, as that could trigger rate limiting and cause one of your processes to fail to trade.
+
 # 4.0.1
 
 - corrected total paid calculation on startup log (UI only change)

--- a/index.js
+++ b/index.js
@@ -112,29 +112,28 @@ const startEngine = async () => {
   const currentHolding = add(memory.lastLog.Holding, memory.lastLog.Shares);
   const holdingValue = multiply(ticker.price, currentHolding);
   const liquidValue = add(holdingValue, memory.lastLog.Realized);
+  const totalCost = add(
+    memory.lastLog.TotalInput,
+    memory.lastLog.Funds > 0 ? memory.lastLog.Funds : 0
+  );
   log.now(
     `🕟 next run ${nextDate.fromNow()}, on ${nextDate
       .local()
       .format()}, holding ${currentHolding} @${
       ticker.price
-    } (market) = $${holdingValue}, paid ${memory.lastLog.TotalInput.toFixed(
-      2
-    )},` +
+    } (market) = $${holdingValue}, paid ${totalCost.toFixed(2)},` +
       // ` target APY calculation ${multiply(
       //   getAPY({
-      //     totalInput: memory.lastLog.TotalInput,
+      //     totalInput: totalCost,
       //     endValue: holdingValue,
       //     dateNow: new Date(),
       //   }),
       //   100
       // ).toFixed(2)}%`+
       ` liquid gain ${
-        memory.lastLog.TotalInput
+        totalCost
           ? multiply(
-              divide(
-                subtract(liquidValue, memory.lastLog.TotalInput),
-                memory.lastLog.TotalInput
-              ),
+              divide(subtract(liquidValue, totalCost), totalCost),
               100
             ).toFixed(2)
           : 0

--- a/index.js
+++ b/index.js
@@ -16,9 +16,9 @@ const job = new CronJob(config.freq, action);
 
 const startEngine = async () => {
   const product = await getProduct(config.productID);
-  product.precision = product.base_increment
-    .replace('0.', '')
-    .replace(/1[0]+/, '1').length;
+  product.precision = product.base_increment.includes('0.')
+    ? product.base_increment.replace('0.', '').replace(/1[0]+/, '1').length
+    : 0;
   memory.product = product;
   // log.now({product})
   log.now(

--- a/lib/action.js
+++ b/lib/action.js
@@ -10,8 +10,15 @@ const logSave = require('./log.save');
 const postRebuys = require('./rebuys.post');
 const postResells = require('./resells.post');
 const checkLimits = require('./limit.check');
-
+const sleep = require('./sleep');
+function getRandomInt(max) {
+  return Math.floor(Math.random() * max);
+}
 module.exports = async (opts = {}) => {
+  // bot detection/manipulation delay
+  if (process.env.CPBB_RANDOM_DELAY) {
+    await sleep(getRandomInt(process.env.CPBB_RANDOM_DELAY * 60 * 1000));
+  }
   // before processing this period, we need to check on any pending market rebuy orders
   if (memory.makerOrders.length) {
     await checkLimits(opts);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coinbase_position_builder_bot",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Position Building Bot for Accumulating Bitcoin (or other assets) via Coinbase Pro, while taking advantage of pumps",
   "jest": {
     "collectCoverageFrom": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coinbase_position_builder_bot",
-  "version": "4.0.1",
+  "version": "4.1.0",
   "description": "Position Building Bot for Accumulating Bitcoin (or other assets) via Coinbase Pro, while taking advantage of pumps",
   "jest": {
     "collectCoverageFrom": [

--- a/run.mine.config.js
+++ b/run.mine.config.js
@@ -19,8 +19,11 @@ module.exports = {
         CPBB_CURRENCY: 'USD',
         CPBB_VOL: 400,
         CPBB_APY: 100,
+        CPBB_RESELL_MAX: 400,
+        CPBB_RESELL: '1@10',
         // max $ spend on limit rebuys
-        // CPBB_REBUY_MAX: 50,
+        CPBB_REBUY_MAX: 400,
+        CPBB_REBUY: '1@10',
         // minimum order is .0001 BTC ($5 at $50K)
         // rebuy logic will place up orders at this size until CPBB_REBUY_MAX is reached
         // CPBB_REBUY:
@@ -60,15 +63,7 @@ module.exports = {
         CPBB_CURRENCY: 'USD',
         CPBB_VOL: 100,
         CPBB_APY: 20,
-        // max $ spend on limit rebuys
-        // CPBB_REBUY_MAX: 10,
-        // // minimum order is .001 ETH ($5 at $5K)
-        // // rebuy logic will place orders at this size until CPBB_REBUY_MAX is reached
-        // CPBB_REBUY:
-        //   '.001@4,.002@5,.003@6,.004@8,.005@10,.01@15,.02@20,.04@25,.08@30,.16@35,.32@40,.64@50,1.28@60,2.56@70,5.12@80,10.24@90',
-        // CPBB_REBUY_CANCEL: 60 * 24 * 14,
-        // CPBB_REBUY_REBUILD: 35,
-        CPBB_RESELL_MAX: 25,
+        CPBB_RESELL_MAX: 100,
         CPBB_RESELL: '10@5',
       },
     },
@@ -86,17 +81,7 @@ module.exports = {
         CPBB_CURRENCY: 'USD',
         CPBB_VOL: 50,
         CPBB_APY: 15,
-        // max $ spend on limit rebuys
-        // CPBB_REBUY_MAX: 10,
-        // // minimum order is in LTC (.01, which is $5 at $500)
-        // // rebuy logic will place orders at this size until CPBB_REBUY_MAX is reached
-        // CPBB_REBUY:
-        //   '.01@4,.02@5,.03@6,.04@8,.05@10,.1@15,.2@20,.4@25,.8@30,1.6@35,3.2@40,6.4@50,12.8@60,25.6@70,51.2@80,102.4@90',
-        // CPBB_REBUY_CANCEL: 60 * 24 * 14,
-        // CPBB_REBUY_REBUILD: 20,
-        // sell up to $5 worth of asset
-        CPBB_RESELL_MAX: 25,
-        // sell up to 10 units of asset @ +5% pump
+        CPBB_RESELL_MAX: 50,
         CPBB_RESELL: '10@5',
         // no rebuild, auto cancel before next run
       },
@@ -115,9 +100,8 @@ module.exports = {
         CPBB_CURRENCY: 'USD',
         CPBB_VOL: 20,
         CPBB_APY: 10,
-        // sell up to $5 worth of DASH
         CPBB_RESELL_MAX: 20,
-        // sell up to 100 DASH @ +5% pump
+        // sell up to 100 DASH @ +4% pump
         CPBB_RESELL: '100@5',
         // no rebuild, auto cancel before next run
       },
@@ -135,17 +119,9 @@ module.exports = {
         CPBB_TICKER: 'XTZ',
         CPBB_CURRENCY: 'USD',
         CPBB_VOL: 50,
-        CPBB_APY: 50,
-        // max $ spend on limit rebuys
-        // CPBB_REBUY_MAX: 10,
-        // // minimum order is 1 XTZ, with a max precision of .01 XTZ
-        // CPBB_REBUY:
-        //   '1@4,2@5,3@6,4@8,5@10,6@12,7@14,8@16,9@18,10@20,11@22,12@24,13@26,14@28,15@30,16@32,17@34,18@36,19@38,20@40,25@50,50@60,100@80',
-        // CPBB_REBUY_CANCEL: 60 * 24 * 14,
-        // CPBB_REBUY_REBUILD: 25,
-        // sell up to $5 worth of asset
+        CPBB_APY: 25,
         CPBB_RESELL_MAX: 50,
-        // sell up to 100 units of asset @ +5% pump
+        // sell up to 100 units of asset @ +4% pump
         CPBB_RESELL: '100@5',
         // no rebuild, auto cancel before next run
       },
@@ -164,9 +140,8 @@ module.exports = {
         CPBB_CURRENCY: 'USD',
         CPBB_VOL: 10,
         CPBB_APY: 10,
-        // sell up to $5 worth of asset
         CPBB_RESELL_MAX: 10,
-        // sell up to 100 units of asset @ +5% pump
+        // sell up to 100 units of asset @ +4% pump
         CPBB_RESELL: '100@5',
         // no rebuild, auto cancel before next run
       },

--- a/run.mine.config.js
+++ b/run.mine.config.js
@@ -144,5 +144,17 @@ module.exports = {
         },
       },
     },
+    {
+      name: 'dot',
+      script,
+      watch: watch,
+      env: {
+        ...baseConfigEnv,
+        ...{
+          CPBB_FREQ: '33 6 * * *',
+          CPBB_TICKER: 'DOT',
+        },
+      },
+    },
   ],
 };

--- a/run.mine.config.js
+++ b/run.mine.config.js
@@ -20,6 +20,9 @@ const baseConfigEnv = {
   CPBB_REBUY_MAX: 10,
   // rebuy up to 1000 units of asset @ -10% dump
   CPBB_REBUY: '1000@10',
+  // randomly shift the cron timer by up to 5 minutes
+  // to prevent bot detection/manipulation
+  CPBB_RANDOM_DELAY: 5,
 };
 module.exports = {
   apps: [
@@ -138,18 +141,6 @@ module.exports = {
         ...{
           CPBB_FREQ: '23 6 * * *',
           CPBB_TICKER: 'MATIC',
-        },
-      },
-    },
-    {
-      name: 'poly',
-      script,
-      watch: watch,
-      env: {
-        ...baseConfigEnv,
-        ...{
-          CPBB_FREQ: '33 6 * * *',
-          CPBB_TICKER: 'POLY',
         },
       },
     },

--- a/run.mine.config.js
+++ b/run.mine.config.js
@@ -1,51 +1,45 @@
 const apiKeys = require('./api.keys');
 const script = '.';
 const watch = ['./index.js', './config.js', 'coinbase/*.js', 'lib/*.js'];
+
+// base environmental variable config for alts
+// these operate at a low APY threshold and volume to feed BTC
+const baseConfigEnv = {
+  NODE_ENV: 'production',
+  CPBB_APIPASS: apiKeys.CPBB_APIPASS,
+  CPBB_APIKEY: apiKeys.CPBB_APIKEY,
+  CPBB_APISEC: apiKeys.CPBB_APISEC,
+  CPBB_FREQ: '0 6 * * *',
+  CPBB_TICKER: 'TEST',
+  CPBB_CURRENCY: 'USD',
+  CPBB_VOL: 10,
+  CPBB_APY: 20,
+  CPBB_RESELL_MAX: 10,
+  // resell up to 1000 units of asset @ +5% pump
+  CPBB_RESELL: '1000@5',
+  CPBB_REBUY_MAX: 10,
+  // rebuy up to 1000 units of asset @ -10% dump
+  CPBB_REBUY: '1000@10',
+};
 module.exports = {
   apps: [
     {
-      // CPBB_FREQ="35 */4 * * *" CPBB_VOL=50 CPBB_APY=15 node project.forward.js
       name: 'btc',
       script,
       watch,
       env: {
-        VERBOSE: false,
-        NODE_ENV: 'production',
-        CPBB_APIPASS: apiKeys.CPBB_APIPASS,
-        CPBB_APIKEY: apiKeys.CPBB_APIKEY,
-        CPBB_APISEC: apiKeys.CPBB_APISEC,
-        CPBB_FREQ: '02 5 * * *',
-        CPBB_TICKER: 'BTC',
-        CPBB_CURRENCY: 'USD',
-        CPBB_VOL: 400,
-        CPBB_APY: 100,
-        CPBB_RESELL_MAX: 400,
-        CPBB_RESELL: '1@10',
-        // max $ spend on limit rebuys
-        CPBB_REBUY_MAX: 400,
-        CPBB_REBUY: '1@10',
-        // minimum order is .0001 BTC ($5 at $50K)
-        // rebuy logic will place up orders at this size until CPBB_REBUY_MAX is reached
-        // CPBB_REBUY:
-        // '.0001@3,.0005@6,.001@9,.005@12,.01@15,.05@20,.1@25,.5@30,1@50',
-        // when should we cancel limit orders?
-        // default behavior is on the next action point (if they didn't fill)
-        // if CPBB_REBUY_CANCEL is set, this is a number of minutes after the limit order
-        // creation timestamp that it will be considered ready to cancel if not filled
-        // CPBB_REBUY_CANCEL: 60 * 24 * 14,
-        // if there are this many unfilled limit orders remaining on the books, expire them
-        // and rebuild the limit order set immediately using the sum total of funds
-        // used for all the limit orders and starting with the price at the highest limit value
-        // using the rebuy config to create new orders
-        // NOTE: if you use this setting, it is recommended that you set it higher than
-        // the number of items in your CPBB_REBUY config so it doesn't excessively rebuild
-        // the same orders over and over
-        // CPBB_REBUY_REBUILD: 35,
-        // sell up to $50 worth of asset
-        // CPBB_RESELL_MAX: 50,
-        // sell up to 1 units of asset @ +10% pump
-        // CPBB_RESELL: '1@10',
-        // no rebuild, auto cancel before next run
+        ...baseConfigEnv,
+        ...{
+          VERBOSE: false,
+          CPBB_FREQ: '02 5 * * *',
+          CPBB_TICKER: 'BTC',
+          CPBB_VOL: 400,
+          CPBB_APY: 100,
+          CPBB_RESELL_MAX: 400,
+          CPBB_RESELL: '1@10',
+          CPBB_REBUY_MAX: 400,
+          CPBB_REBUY: '1@10',
+        },
       },
     },
     {
@@ -53,18 +47,14 @@ module.exports = {
       script,
       watch: watch,
       env: {
-        // VERBOSE: true,
-        NODE_ENV: 'production',
-        CPBB_APIPASS: apiKeys.CPBB_APIPASS,
-        CPBB_APIKEY: apiKeys.CPBB_APIKEY,
-        CPBB_APISEC: apiKeys.CPBB_APISEC,
-        CPBB_FREQ: '42 5 * * *',
-        CPBB_TICKER: 'ETH',
-        CPBB_CURRENCY: 'USD',
-        CPBB_VOL: 100,
-        CPBB_APY: 20,
-        CPBB_RESELL_MAX: 100,
-        CPBB_RESELL: '10@5',
+        ...baseConfigEnv,
+        ...{
+          CPBB_FREQ: '12 5 * * *',
+          CPBB_TICKER: 'ETH',
+          CPBB_VOL: 100,
+          CPBB_RESELL_MAX: 100,
+          CPBB_REBUY_MAX: 100,
+        },
       },
     },
     {
@@ -72,18 +62,11 @@ module.exports = {
       script,
       watch: watch,
       env: {
-        NODE_ENV: 'production',
-        CPBB_APIPASS: apiKeys.CPBB_APIPASS,
-        CPBB_APIKEY: apiKeys.CPBB_APIKEY,
-        CPBB_APISEC: apiKeys.CPBB_APISEC,
-        CPBB_FREQ: '18 6 * * *',
-        CPBB_TICKER: 'LTC',
-        CPBB_CURRENCY: 'USD',
-        CPBB_VOL: 50,
-        CPBB_APY: 15,
-        CPBB_RESELL_MAX: 50,
-        CPBB_RESELL: '10@5',
-        // no rebuild, auto cancel before next run
+        ...baseConfigEnv,
+        ...{
+          CPBB_FREQ: '22 5 * * *',
+          CPBB_TICKER: 'LTC',
+        },
       },
     },
     {
@@ -91,19 +74,11 @@ module.exports = {
       script,
       watch: watch,
       env: {
-        NODE_ENV: 'production',
-        CPBB_APIPASS: apiKeys.CPBB_APIPASS,
-        CPBB_APIKEY: apiKeys.CPBB_APIKEY,
-        CPBB_APISEC: apiKeys.CPBB_APISEC,
-        CPBB_FREQ: '35 6 * * *',
-        CPBB_TICKER: 'DASH',
-        CPBB_CURRENCY: 'USD',
-        CPBB_VOL: 20,
-        CPBB_APY: 10,
-        CPBB_RESELL_MAX: 20,
-        // sell up to 100 DASH @ +4% pump
-        CPBB_RESELL: '100@5',
-        // no rebuild, auto cancel before next run
+        ...baseConfigEnv,
+        ...{
+          CPBB_FREQ: '32 5 * * *',
+          CPBB_TICKER: 'DASH',
+        },
       },
     },
     {
@@ -111,19 +86,11 @@ module.exports = {
       script,
       watch: watch,
       env: {
-        NODE_ENV: 'production',
-        CPBB_APIPASS: apiKeys.CPBB_APIPASS,
-        CPBB_APIKEY: apiKeys.CPBB_APIKEY,
-        CPBB_APISEC: apiKeys.CPBB_APISEC,
-        CPBB_FREQ: '46 6 * * *',
-        CPBB_TICKER: 'XTZ',
-        CPBB_CURRENCY: 'USD',
-        CPBB_VOL: 50,
-        CPBB_APY: 25,
-        CPBB_RESELL_MAX: 50,
-        // sell up to 100 units of asset @ +4% pump
-        CPBB_RESELL: '100@5',
-        // no rebuild, auto cancel before next run
+        ...baseConfigEnv,
+        ...{
+          CPBB_FREQ: '42 5 * * *',
+          CPBB_TICKER: 'XTZ',
+        },
       },
     },
     {
@@ -131,19 +98,59 @@ module.exports = {
       script,
       watch: watch,
       env: {
-        NODE_ENV: 'production',
-        CPBB_APIPASS: apiKeys.CPBB_APIPASS,
-        CPBB_APIKEY: apiKeys.CPBB_APIKEY,
-        CPBB_APISEC: apiKeys.CPBB_APISEC,
-        CPBB_FREQ: '53 6 * * *',
-        CPBB_TICKER: 'DOGE',
-        CPBB_CURRENCY: 'USD',
-        CPBB_VOL: 10,
-        CPBB_APY: 10,
-        CPBB_RESELL_MAX: 10,
-        // sell up to 100 units of asset @ +4% pump
-        CPBB_RESELL: '100@5',
-        // no rebuild, auto cancel before next run
+        ...baseConfigEnv,
+        ...{
+          CPBB_FREQ: '52 5 * * *',
+          CPBB_TICKER: 'DOGE',
+        },
+      },
+    },
+    {
+      name: 'ada',
+      script,
+      watch: watch,
+      env: {
+        ...baseConfigEnv,
+        ...{
+          CPBB_FREQ: '3 6 * * *',
+          CPBB_TICKER: 'ADA',
+        },
+      },
+    },
+    {
+      name: 'algo',
+      script,
+      watch: watch,
+      env: {
+        ...baseConfigEnv,
+        ...{
+          CPBB_FREQ: '13 6 * * *',
+          CPBB_TICKER: 'ALGO',
+        },
+      },
+    },
+    {
+      name: 'matic',
+      script,
+      watch: watch,
+      env: {
+        ...baseConfigEnv,
+        ...{
+          CPBB_FREQ: '23 6 * * *',
+          CPBB_TICKER: 'MATIC',
+        },
+      },
+    },
+    {
+      name: 'poly',
+      script,
+      watch: watch,
+      env: {
+        ...baseConfigEnv,
+        ...{
+          CPBB_FREQ: '33 6 * * *',
+          CPBB_TICKER: 'POLY',
+        },
       },
     },
   ],

--- a/test/data/output.engine.log
+++ b/test/data/output.engine.log
@@ -7,7 +7,7 @@
 🏦 $USD account loaded with 9900.2266348066930000/10000.2301373066930000 (99 buy actions)
 ✅ last transaction for TEST-USD:
 🤑 [DATE] 0 0.00000000 TEST ➡️  $0 @0	✊ 0.00000000 @0.00 =$0 💧 gain 0.00, basis 0.00 💵 0.00 💹 0 💸 <Infinity
-🕟 next run in 7 months, on [DATE] holding 0 @50000.00 (market) = $0, paid 0.00, liquid gain 0%
+🕟 next run in [RUNTIME], on [DATE] holding 0 @50000.00 (market) = $0, paid 0.00, liquid gain 0%
 💸 [DATE] cron $100 ➡️  0.00199000 TEST @50000.00	✊ 0.00199000 @50251.26 =$100 💧 gain 0.00, basis 50251.26 💵 0.00 💹 0.00% 💸 <50251.26
 🤑 [DATE] resell 0.00010000 TEST ➡️  $5.07 @51000.00	✊ 0.00189000 @50225.13 =$94.93 💧 gain 11.64, basis 50225.13 💵 0.00 💹 12.26% 💸 <50261.35
 💸 [DATE] cron $100 ➡️  0.00195060 TEST @51009.95	✊ 0.00384060 @50753.92 =$194.93 💧 gain 1.48, basis 50753.92 💵 0.00 💹 0.76% 💸 <50771.74

--- a/test/lib/log.js
+++ b/test/lib/log.js
@@ -15,6 +15,7 @@ global.console.log = (...args) => {
       /Position Builder Bot .+, http/,
       `Position Builder Bot [VERSION], http`
     )
+    .replace(/next run in [^,]+, on/, `next run in [RUNTIME], on`)
     .replace(
       /[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/gi,
       '[UUID]'

--- a/tools/create.history.js
+++ b/tools/create.history.js
@@ -52,21 +52,22 @@ log.ok(`backed up history file in ${backup}`);
     //   log.debug('no volume?', f);
     // }
     const funds = multiply(f.price, f.size);
+    const Funds = f.side === 'sell' ? multiply(funds, -1) : funds;
     return {
       Time: f.created_at,
       Price: f.price,
       Holding: 0,
       Value: 0,
-      Funds: f.side === 'sell' ? multiply(funds, -1) : funds,
+      Funds,
       Shares: f.side === 'sell' ? multiply(f.size, -1) : f.size,
       PeriodRate: 0,
       ExpectedGain: 0,
-      TotalInput: 0,
-      Target: 0,
-      Diff: 0,
-      EndValue: 0,
+      TotalInput: Funds,
+      Target: Funds,
+      Diff: -Funds,
+      EndValue: Funds,
       Realized: 0,
-      TotalValue: 0,
+      TotalValue: Funds,
       Liquid: 0,
       Profit: 0,
       ID: f.order_id,


### PR DESCRIPTION
# 4.1.0

- `CPBB_RANDOM_DELAY` environmental config option can be set to a maximum number of minutes to randomly delay the cron event. For example, setting `CPBB_RANDOM_DELAY: 5` will make each cron action wait a random number of milliseconds between 0 and 5 minutes from the triggered cron event time before running the action. This helps to avoid being detected and manipulated by bots as an agent that always does a buy action of a certain dollar amount every day at 10am UTC. This regularity is something manipulators can notice in the stream of event data coming from the trading API and use to time high volume trading manipulation, knowing that you will eat into their limit orders at whatever point they can manipulate the order books into being at the time your regular cron action triggers. In short, it is `recommended` to set this value to something though the default value is 0 to keep the [principle of least astonishment](https://en.wikipedia.org/wiki/Principle_of_least_astonishment). Note that you should provide enough buffer between multiple engines so they don't occasonally run queries at the same time, as that could trigger rate limiting and cause one of your processes to fail to trade.
- Fix issue with `tools/create.history.js` that caused the first row of data to not be counted in the totals
